### PR TITLE
Enhance salary's system

### DIFF
--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/ConfigureServices.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/ConfigureServices.cs
@@ -1,9 +1,11 @@
 ﻿using Freaks.Bll.Common.Extensions;
+using Freaks.Messages.Common;
 using Freaks.Portal.Bll.Implementation.Auction;
 using Freaks.Portal.Bll.Implementation.Loot;
 using Freaks.Portal.Bll.Implementation.Notification;
 using Freaks.Portal.Bll.Implementation.RaidSummary;
 using Freaks.Portal.Bll.Implementation.SalarySummary;
+using Freaks.Portal.Bll.Implementation.SalarySummary.Mappings;
 using Freaks.Portal.Bll.Implementation.Shop;
 using Freaks.Portal.Bll.Interfaces.Auction;
 using Freaks.Portal.Bll.Interfaces.Loot;
@@ -11,6 +13,7 @@ using Freaks.Portal.Bll.Interfaces.Notification;
 using Freaks.Portal.Bll.Interfaces.RaidSummary;
 using Freaks.Portal.Bll.Interfaces.SalarySummary;
 using Freaks.Portal.Bll.Interfaces.Shop;
+using Mapster;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -57,9 +60,15 @@ public static class ConfigureServices
         services.AddScoped<IAuctionItemService, AuctionItemService>();
         services.AddScoped<IAuctionItemBidService, AuctionItemBidService>();
         
-        //Notification
+        // Notification
         services.AddScoped<INotificationChannelMessageService, NotificationChannelMessageService>();
         services.AddScoped<INotificationChannelService, NotificationChannelService>();
+
+        // Mapper
+        services.AddMapsterCommon(typeof(SalaryGuildLeaderMappingProfile).Assembly);
+
+        // Real-Time messages
+        services.AddCentrifugoMessageService(configuration);
         
         return services;
     }

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/Freaks.Portal.Bll.Implementation.csproj
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/Freaks.Portal.Bll.Implementation.csproj
@@ -11,6 +11,7 @@
         <ProjectReference Include="..\..\..\..\Shared\Freaks.Bll.Common\Freaks.Bll.Common.csproj"/>
         <ProjectReference Include="..\..\..\..\Shared\Freaks.Common\Freaks.Common.csproj" />
         <ProjectReference Include="..\..\..\..\Shared\Messages\Freaks.Messages.Bll\Freaks.Messages.Bll.csproj"/>
+        <ProjectReference Include="..\..\..\..\Shared\Messages\Freaks.Messages.Common\Freaks.Messages.Common.csproj" />
         <ProjectReference Include="..\..\Dal\Freaks.Portal.Dal.Interfaces\Freaks.Portal.Dal.Interfaces.csproj"/>
         <ProjectReference Include="..\Freaks.Portal.Bll.Interfaces\Freaks.Portal.Bll.Interfaces.csproj"/>
     </ItemGroup>

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Algorithms/BasicSalaryAlgorithm.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Algorithms/BasicSalaryAlgorithm.cs
@@ -1,3 +1,4 @@
+using Freaks.Portal.Bll.Implementation.SalarySummary.Helpers;
 using Freaks.Portal.Contracts.Entities.SalarySummary;
 using Freaks.Portal.Contracts.ValueObjects.RaidSummary;
 using Freaks.Portal.SharedContracts.ValueObjects.Loot;
@@ -101,7 +102,7 @@ public class BasicSalaryAlgorithm
     private decimal CalculateDistributionPool()
     {
         var totalLootAmount = _loot.Sum(l => l.Amount);
-        var guildLeaderAmount = _guildLeader.Sum(g => g.Amount);
+        var guildLeaderAmount = _guildLeader.Sum(g => SalaryGuildLeaderHelper.CalculateAmount(g.SalaryLoot, g.Quantity));
         var expensesAmount = _expenses.Sum(e => e.Amount);
 
         return totalLootAmount - guildLeaderAmount - expensesAmount;

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Helpers/SalaryGuildLeaderHelper.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Helpers/SalaryGuildLeaderHelper.cs
@@ -2,8 +2,17 @@
 
 namespace Freaks.Portal.Bll.Implementation.SalarySummary.Helpers;
 
+/// <summary>
+///     Вспомогательный класс для расчётов, связанных с долей руководства гильдии.
+/// </summary>
 public static class SalaryGuildLeaderHelper
 {
+    /// <summary>
+    ///     Рассчитывает итоговую сумму для доли руководства гильдии на основе проданного лута и количества.
+    /// </summary>
+    /// <param name="salaryLoot">Информация о проданном луте зарплатного периода.</param>
+    /// <param name="quantity">Количество предметов для расчёта.</param>
+    /// <returns>Рассчитанная сумма. Возвращает 0, если данные о луте отсутствуют.</returns>
     public static decimal CalculateAmount(SalaryLoot? salaryLoot, int quantity)
     {
         var result = salaryLoot?.Amount / salaryLoot?.Quantity * quantity;

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Helpers/SalaryGuildLeaderHelper.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Helpers/SalaryGuildLeaderHelper.cs
@@ -1,0 +1,13 @@
+﻿using Freaks.Portal.Contracts.Entities.SalarySummary;
+
+namespace Freaks.Portal.Bll.Implementation.SalarySummary.Helpers;
+
+public static class SalaryGuildLeaderHelper
+{
+    public static decimal CalculateAmount(SalaryLoot? salaryLoot, int quantity)
+    {
+        var result = salaryLoot?.Amount / salaryLoot?.Quantity * quantity;
+
+        return result.GetValueOrDefault(0);
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Mappings/SalaryGuildLeaderMappingProfile.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Mappings/SalaryGuildLeaderMappingProfile.cs
@@ -1,0 +1,15 @@
+﻿using Freaks.Portal.Bll.Implementation.SalarySummary.Helpers;
+using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+using Mapster;
+
+namespace Freaks.Portal.Bll.Implementation.SalarySummary.Mappings;
+
+public class SalaryGuildLeaderMappingProfile : IRegister
+{
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<SalaryGuildLeader, SalaryGuildLeaderDto>()
+            .Map(dest => dest.Amount, src => SalaryGuildLeaderHelper.CalculateAmount(src.SalaryLoot, src.Quantity));
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Mappings/SalaryGuildLeaderMappingProfile.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Mappings/SalaryGuildLeaderMappingProfile.cs
@@ -5,8 +5,15 @@ using Mapster;
 
 namespace Freaks.Portal.Bll.Implementation.SalarySummary.Mappings;
 
+/// <summary>
+///     Профиль маппинга для преобразования сущности <see cref="SalaryGuildLeader"/> в DTO <see cref="SalaryGuildLeaderDto"/>.
+/// </summary>
 public class SalaryGuildLeaderMappingProfile : IRegister
 {
+    /// <summary>
+    ///     Регистрирует правила маппинга для доли руководства гильдии в конфигурации Mapster.
+    /// </summary>
+    /// <param name="config">Конфигурация Mapster для регистрации правил маппинга.</param>
     public void Register(TypeAdapterConfig config)
     {
         config.NewConfig<SalaryGuildLeader, SalaryGuildLeaderDto>()

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryGuildLeaderService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryGuildLeaderService.cs
@@ -66,16 +66,12 @@ public class SalaryGuildLeaderService : ISalaryGuildLeaderService
         {
             await _stepService.HandleStepActionAsync(salaryId, SalaryFillStepType.GuildLeaderSalary);
 
-            var amount = request.Quantity * request.PricePerItem;
-
             var entity =
                 new SalaryGuildLeader
                 {
+                    Id = request.SalaryLootId,
                     SalaryId = salaryId,
-                    LootId = request.LootId,
                     Quantity = request.Quantity,
-                    PricePerItem = request.PricePerItem,
-                    Amount = amount,
                 };
 
             var result = await _provider.CreateAsync(entity);
@@ -87,23 +83,19 @@ public class SalaryGuildLeaderService : ISalaryGuildLeaderService
     }
 
     /// <inheritdoc />
-    public Task<SalaryGuildLeaderDto> UpdateAsync(long salaryId, long guildLeaderId, UpdateSalaryGuildLeaderRequest request)
+    public Task<SalaryGuildLeaderDto> UpdateAsync(long salaryId, long salaryLootId, UpdateSalaryGuildLeaderRequest request)
     {
         return _unitOfWork.ExecuteInsideTransactionAsync(async _ =>
         {
             await _stepService.HandleStepActionAsync(salaryId, SalaryFillStepType.GuildLeaderSalary);
 
-            var entity = await _provider.GetAsync(guildLeaderId, EntityTrackingType.NoTracking);
+            var entity = await _provider.GetAsync(salaryLootId, EntityTrackingType.NoTracking);
             if (entity is null)
             {
                 throw new EntityNotFoundException(nameof(SalaryGuildLeader));
             }
 
-            entity.LootId = request.LootId;
             entity.Quantity = request.Quantity;
-            entity.PricePerItem = request.PricePerItem;
-
-            entity.Amount = entity.Quantity * entity.PricePerItem;
 
             var result = await _provider.UpdateAsync(entity);
 
@@ -114,19 +106,19 @@ public class SalaryGuildLeaderService : ISalaryGuildLeaderService
     }
 
     /// <inheritdoc />
-    public Task DeleteAsync(long salaryId, long guildLeaderId)
+    public Task DeleteAsync(long salaryId, long salaryLootId)
     {
         return _unitOfWork.ExecuteInsideTransactionAsync(async _ =>
         {
             await _stepService.HandleStepActionAsync(salaryId, SalaryFillStepType.GuildLeaderSalary);
 
-            var entity = await _provider.GetAsync(guildLeaderId, EntityTrackingType.NoTracking);
+            var entity = await _provider.GetAsync(salaryLootId, EntityTrackingType.NoTracking);
             if (entity is null)
             {
                 return;
             }
 
-            await _provider.DeleteAsync(guildLeaderId);
+            await _provider.DeleteAsync(salaryLootId);
 
             await PublishMessageAsync(salaryId, EntityActionType.Deleted);
         });

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryLootService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryLootService.cs
@@ -1,3 +1,4 @@
+using Freaks.Common.Extensions;
 using Freaks.Dal.Common.Interfaces;
 using Freaks.Dal.Common.ValueObjects;
 using Freaks.Messages.Bll.Interfaces;
@@ -5,9 +6,12 @@ using Freaks.Messages.SharedContracts.Messages.SalarySummary;
 using Freaks.Messages.SharedContracts.ValueObjects;
 using Freaks.Portal.Bll.Interfaces.SalarySummary;
 using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.Contracts.ValueObjects.RaidSummary;
+using Freaks.Portal.Dal.Interfaces.RaidSummary;
 using Freaks.Portal.Dal.Interfaces.SalarySummary;
 using Freaks.Portal.Dal.Persistence;
 using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+using Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader;
 using Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryLoot;
 using Freaks.Portal.SharedContracts.ValueObjects.SalarySummary;
 using Freaks.WebApi.Common.Exceptions;
@@ -25,6 +29,8 @@ public class SalaryLootService : ISalaryLootService
     private readonly IMapper _mapper;
     private readonly ISalaryLootProvider _provider;
     private readonly ISalaryStepService _stepService;
+    private readonly ISalaryProvider _salaryProvider;
+    private readonly IRaidProvider _raidProvider;
     private readonly IMessageService _messageService;
     private readonly IUnitOfWork<PortalDbContext> _unitOfWork;
 
@@ -34,6 +40,8 @@ public class SalaryLootService : ISalaryLootService
     /// <param name="mapper">Сервис Mapster для преобразования сущностей в DTO и обратно.</param>
     /// <param name="provider">Провайдер доступа к данным проданного лута зарплатных периодов.</param>
     /// <param name="stepService">Сервис степпера зарплатных периодов.</param>
+    /// <param name="salaryProvider">Провайдер доступа к данным зарплатных периодов.</param>
+    /// <param name="raidProvider">Провайдер доступа к данным рейдов.</param>
     /// <param name="messageService">Сервис для публикации сообщений в систему обмена сообщениями.</param>
     /// <param name="unitOfWork">Unit of Work</param>
     /// <exception cref="ArgumentNullException">Выбрасывается, если любой из аргументов равен null.</exception>
@@ -41,12 +49,16 @@ public class SalaryLootService : ISalaryLootService
         IMapper mapper,
         ISalaryLootProvider provider,
         ISalaryStepService stepService,
+        ISalaryProvider salaryProvider,
+        IRaidProvider raidProvider,
         IMessageService messageService,
         IUnitOfWork<PortalDbContext> unitOfWork)
     {
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         _provider = provider ?? throw new ArgumentNullException(nameof(provider));
         _stepService = stepService ?? throw new ArgumentNullException(nameof(stepService));
+        _salaryProvider = salaryProvider ?? throw new ArgumentNullException(nameof(salaryProvider));
+        _raidProvider = raidProvider ?? throw new ArgumentNullException(nameof(raidProvider));
         _messageService = messageService ?? throw new ArgumentNullException(nameof(messageService));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
@@ -131,6 +143,42 @@ public class SalaryLootService : ISalaryLootService
             await PublishMessageAsync(salaryId, EntityActionType.Updated);
 
             return _mapper.Map<SalaryLootDto>(result);
+        });
+    }
+
+    /// <inheritdoc />
+    public Task FillByRaidsAsync(long salaryId, FillByRaidsRequest request)
+    {
+        return _unitOfWork.ExecuteInsideTransactionAsync(async _ =>
+        {
+            await _stepService.HandleStepActionAsync(salaryId, SalaryFillStepType.SoldByPeriod);
+
+            var salary = await _salaryProvider.GetAsync(salaryId, EntityTrackingType.NoTracking);
+            if (salary is null)
+            {
+                throw new EntityNotFoundException(nameof(Salary));
+            }
+
+            var raids = await _raidProvider.GetFullInfoAsync(salary.StartDt.ToDateTimeOffset(), salary.EndDt.AddDays(1).ToDateTimeOffset(), salary.BossTypes);
+
+            await _provider.DeleteBySalaryIdAsync(salaryId);
+
+            var salaryLoots = raids
+                .SelectMany(r => r.Loot)
+                .Where(l => request.LootIds.Contains(l.LootItemId))
+                .GroupBy(l => l.LootItemId)
+                .Select(gl => new SalaryLoot
+                {
+                    SalaryId = salaryId,
+                    LootId = gl.Key,
+                    Quantity = gl.Sum(l => l.Quantity),
+                    PricePerItem = 0,
+                    DiscountPercent = 0,
+                    Amount = 0
+                }).ToList();
+            await _provider.SetAsync(salaryLoots);
+
+            await PublishMessageAsync(salaryId, EntityActionType.Updated);
         });
     }
 

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Interfaces/SalarySummary/ISalaryGuildLeaderService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Interfaces/SalarySummary/ISalaryGuildLeaderService.cs
@@ -29,15 +29,15 @@ public interface ISalaryGuildLeaderService
     ///     Amount пересчитывается по формуле: Quantity * PricePerLoot.
     /// </summary>
     /// <param name="salaryId">Идентификатор зарплатного периода.</param>
-    /// <param name="guildLeaderId">Идентификатор записи доли руководства гильдии.</param>
+    /// <param name="salaryLootId">Идентификатор записи доли руководства гильдии.</param>
     /// <param name="request">Запрос с новой информацией о доле руководства.</param>
     /// <returns>Обновлённая доля руководства гильдии в виде DTO.</returns>
-    Task<SalaryGuildLeaderDto> UpdateAsync(long salaryId, long guildLeaderId, UpdateSalaryGuildLeaderRequest request);
+    Task<SalaryGuildLeaderDto> UpdateAsync(long salaryId, long salaryLootId, UpdateSalaryGuildLeaderRequest request);
 
     /// <summary>
     ///     Удаляет запись о доле руководства гильдии из зарплатного периода.
     /// </summary>
     /// <param name="salaryId">Идентификатор зарплатного периода.</param>
-    /// <param name="guildLeaderId">Идентификатор записи доли руководства гильдии для удаления.</param>
-    Task DeleteAsync(long salaryId, long guildLeaderId);
+    /// <param name="salaryLootId">Идентификатор записи доли руководства гильдии для удаления.</param>
+    Task DeleteAsync(long salaryId, long salaryLootId);
 }

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Interfaces/SalarySummary/ISalaryLootService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Interfaces/SalarySummary/ISalaryLootService.cs
@@ -1,4 +1,5 @@
 using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+using Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader;
 using Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryLoot;
 
 namespace Freaks.Portal.Bll.Interfaces.SalarySummary;
@@ -33,6 +34,14 @@ public interface ISalaryLootService
     /// <param name="request">Запрос с новой информацией о луте.</param>
     /// <returns>Обновлённый проданный лут в виде DTO.</returns>
     Task<SalaryLootDto> UpdateAsync(long salaryId, long lootId, UpdateSalaryLootRequest request);
+
+    /// <summary>
+    ///     Автоматически заполняет проданный лут зарплатного периода на основе данных из рейдов.
+    ///     Удаляет все существующие записи лута за период и создаёт новые на основе указанных предметов из рейдов.
+    /// </summary>
+    /// <param name="salaryId">Идентификатор зарплатного периода.</param>
+    /// <param name="request">Запрос с идентификаторами предметов лута для автоматического заполнения.</param>
+    Task FillByRaidsAsync(long salaryId, FillByRaidsRequest request);
 
     /// <summary>
     ///     Удаляет запись о проданном луте из зарплатного периода.

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/ConfigureServices.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/ConfigureServices.cs
@@ -59,6 +59,8 @@ public static class ConfigureServices
         services.AddScoped<ISalaryGuildLeaderProvider, SalaryGuildLeaderProvider>();
         services.AddScoped<ISalaryLootProvider, SalaryLootProvider>();
 
+        services.AddEasyCachingCommon(configuration);
+
         return services;
     }
 }

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/RaidSummary/RaidLootProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/RaidSummary/RaidLootProvider.cs
@@ -48,8 +48,8 @@ public class RaidLootProvider : BaseCachedCompositeProvider<RaidLoot, RaidLootKe
 
         var result =
             await query
-                .Include(l => l.Loot)
-                  .FirstOrDefaultAsync();
+                    .Include(l => l.Loot)
+                    .FirstOrDefaultAsync();
 
         await SetCachedValueAsync(result, TimeSpan.FromMinutes(5));
         return result;

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryGuildLeaderProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryGuildLeaderProvider.cs
@@ -44,7 +44,8 @@ public class SalaryGuildLeaderProvider : BaseCachedProvider<SalaryGuildLeader, l
 
         var result =
             await query
-                .Include(x => x.LootItem)
+                .Include(x => x.SalaryLoot)
+                .ThenInclude(x => x!.LootItem)
                 .FirstOrDefaultAsync(x => x.Id == key);
 
         await SetCachedValueAsync(result, TimeSpan.FromMinutes(5));
@@ -63,9 +64,10 @@ public class SalaryGuildLeaderProvider : BaseCachedProvider<SalaryGuildLeader, l
 
         var result = await Set
             .AsNoTracking()
-            .Include(x => x.LootItem)
+            .Include(x => x.SalaryLoot)
+            .ThenInclude(x => x!.LootItem)
             .Where(x => x.SalaryId == salaryId)
-            .OrderBy(x => x.LootItem!.Type)
+            .OrderBy(x => x.SalaryLoot!.LootItem!.Type)
             .ToListAsync();
 
         await SetCachedValueAsync(cacheKey, result, TimeSpan.FromMinutes(5));

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryLootProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryLootProvider.cs
@@ -75,6 +75,15 @@ public class SalaryLootProvider : BaseCachedProvider<SalaryLoot, long, IPortalDb
     }
 
     /// <inheritdoc />
+    public async Task DeleteBySalaryIdAsync(long salaryId)
+    {
+        await RemoveCacheAsync(salaryId);
+        await Set
+            .Where(l => l.SalaryId == salaryId)
+            .ExecuteDeleteAsync();
+    }
+
+    /// <inheritdoc />
     protected override string GetCacheKey(long key)
     {
         return $"{nameof(SalaryLoot)}:{key}";

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryMemberProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryMemberProvider.cs
@@ -89,7 +89,7 @@ public class SalaryMemberProvider : BaseCachedCompositeProvider<SalaryMember, Sa
     ///     Генерирует ключ кэша для списка участников зарплатного периода.
     /// </summary>
     /// <param name="salaryId">Идентификатор зарплатного периода.</param>
-    /// <returns>Строковой ключ кэша.</returns>
+    /// <returns>Строковый ключ кэша.</returns>
     private static string GetCacheSalaryKey(long salaryId)
     {
         return $"{nameof(SalaryMember)}:list:salary:{salaryId}";

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Interfaces/SalarySummary/ISalaryLootProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Interfaces/SalarySummary/ISalaryLootProvider.cs
@@ -15,4 +15,10 @@ public interface ISalaryLootProvider : IBaseProvider<SalaryLoot, long, IPortalDb
     /// <param name="salaryId">Идентификатор зарплатного периода.</param>
     /// <returns>Список проданного лута за период.</returns>
     Task<IList<SalaryLoot>> GetBySalaryIdAsync(long salaryId);
+
+    /// <summary>
+    ///     Удаляет все записи проданного лута, связанные с указанным зарплатным периодом.
+    /// </summary>
+    /// <param name="salaryId">Идентификатор зарплатного периода.</param>
+    Task DeleteBySalaryIdAsync(long salaryId);
 }

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Configurations/Salary/SalaryGuildLeaderConfiguration.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Configurations/Salary/SalaryGuildLeaderConfiguration.cs
@@ -17,9 +17,9 @@ public class SalaryGuildLeaderConfiguration : IEntityTypeConfiguration<SalaryGui
             .OnDelete(DeleteBehavior.Cascade);
 
         builder
-            .HasOne(s => s.LootItem)
+            .HasOne(s => s.SalaryLoot)
             .WithMany()
-            .HasForeignKey(s => s.LootId)
+            .HasForeignKey(s => s.Id)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260209061441_alter_salary_guild_leader.Designer.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260209061441_alter_salary_guild_leader.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Freaks.Portal.Dal.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Freaks.Portal.Dal.Persistence.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    partial class PortalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260209061441_alter_salary_guild_leader")]
+    partial class alter_salary_guild_leader
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260209061441_alter_salary_guild_leader.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260209061441_alter_salary_guild_leader.cs
@@ -1,0 +1,137 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Freaks.Portal.Dal.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class alter_salary_guild_leader : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("TRUNCATE TABLE portal.salary_expenses CASCADE;");
+            migrationBuilder.Sql("TRUNCATE TABLE portal.salary_guild_leader CASCADE;");
+            migrationBuilder.Sql("TRUNCATE TABLE portal.salary_loot CASCADE;");
+            migrationBuilder.Sql("TRUNCATE TABLE portal.salary_member CASCADE;");
+            migrationBuilder.Sql("TRUNCATE TABLE portal.salary CASCADE;");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_salary_guild_leader_loot_item_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader");
+
+            migrationBuilder.DropIndex(
+                name: "IX_salary_guild_leader_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader");
+
+            migrationBuilder.DropColumn(
+                name: "amount",
+                schema: "portal",
+                table: "salary_guild_leader");
+
+            migrationBuilder.DropColumn(
+                name: "loot_id",
+                schema: "portal",
+                table: "salary_guild_leader");
+
+            migrationBuilder.DropColumn(
+                name: "price_per_item",
+                schema: "portal",
+                table: "salary_guild_leader");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                newName: "salary_loot_id");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "salary_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_salary_guild_leader_salary_loot_salary_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                column: "salary_loot_id",
+                principalSchema: "portal",
+                principalTable: "salary_loot",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_salary_guild_leader_salary_loot_salary_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader");
+
+            migrationBuilder.RenameColumn(
+                name: "salary_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                newName: "id");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "amount",
+                schema: "portal",
+                table: "salary_guild_leader",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<int>(
+                name: "loot_id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "price_per_item",
+                schema: "portal",
+                table: "salary_guild_leader",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_salary_guild_leader_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                column: "loot_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_salary_guild_leader_loot_item_loot_id",
+                schema: "portal",
+                table: "salary_guild_leader",
+                column: "loot_id",
+                principalSchema: "portal",
+                principalTable: "loot_item",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/Entities/SalarySummary/SalaryGuildLeader.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/Entities/SalarySummary/SalaryGuildLeader.cs
@@ -14,9 +14,8 @@ public class SalaryGuildLeader : IEntity<long>
 {
     /// <inheritdoc />
     [Key]
-    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-    [Column("id")]
-    public long Id { get; init; }
+    [Column("salary_loot_id")]
+    public required long Id { get; init; }
 
     /// <summary>
     ///     Идентификатор зарплатного периода
@@ -25,28 +24,10 @@ public class SalaryGuildLeader : IEntity<long>
     public required long SalaryId { get; init; }
 
     /// <summary>
-    ///     Идентификатор лута
-    /// </summary>
-    [Column("loot_id")]
-    public required int LootId { get; set; }
-
-    /// <summary>
     ///     Количество
     /// </summary>
     [Column("quantity")]
     public required int Quantity { get; set; }
-
-    /// <summary>
-    ///     Цена за единицу лута
-    /// </summary>
-    [Column("price_per_item")]
-    public required decimal PricePerItem { get; set; }
-
-    /// <summary>
-    ///     Сумма
-    /// </summary>
-    [Column("amount")]
-    public required decimal Amount { get; set; }
 
     /// <summary>
     ///     Навигационное свойство для доступа к информации о зарплатном периоде.
@@ -56,5 +37,5 @@ public class SalaryGuildLeader : IEntity<long>
     /// <summary>
     ///     Навигационное свойство для доступа к информации о предмете добычи.
     /// </summary>
-    public LootItem? LootItem { get; init; }
+    public SalaryLoot? SalaryLoot { get; init; }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Dto/SalarySummary/SalaryGuildLeaderDto.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Dto/SalarySummary/SalaryGuildLeaderDto.cs
@@ -1,20 +1,14 @@
-using Freaks.Portal.SharedContracts.Dto.Loot;
-
 namespace Freaks.Portal.SharedContracts.Dto.SalarySummary;
 
 /// <summary>
 ///     DTO, представляющее долю руководства гильдии в зарплатном периоде.
 /// </summary>
-/// <param name="Id">Уникальный идентификатор записи.</param>
+/// <param name="SalaryLoot">Информация о предмете лута зарплатного периода.</param>
 /// <param name="SalaryId">Идентификатор зарплатного периода.</param>
-/// <param name="LootItem">Информация о предмете лута.</param>
 /// <param name="Quantity">Количество предметов.</param>
-/// <param name="PricePerItem">Цена за единицу лута.</param>
 /// <param name="Amount">Итоговая сумма.</param>
 public record SalaryGuildLeaderDto(
-    long Id,
+    SalaryLootDto SalaryLoot,
     long SalaryId,
-    LootItemDto LootItem,
     int Quantity,
-    decimal PricePerItem,
     decimal Amount);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/Salary/Validators/CreateSalaryRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/Salary/Validators/CreateSalaryRequestValidator.cs
@@ -1,4 +1,6 @@
 ﻿using FluentValidation;
+using Freaks.Portal.SharedContracts.ValueObjects.RaidSummary;
+using Freaks.Portal.SharedContracts.ValueObjects.SalarySummary;
 
 namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.Salary.Validators;
 
@@ -8,12 +10,21 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.Salary.Validators
 /// </summary>
 public class CreateSalaryRequestValidator : AbstractValidator<CreateSalaryRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="CreateSalaryRequestValidator"/>.
+    /// </summary>
     public CreateSalaryRequestValidator()
     {
         RuleFor(x => x.Name).NotNull().NotEmpty();
         RuleFor(x => x.StartDt).GreaterThan(default(DateOnly));
         RuleFor(x => x.EndDt).GreaterThan(default(DateOnly));
-        RuleFor(x => x.AllowedPaymentTypes).NotEmpty();
-        RuleFor(x => x.BossTypes).NotEmpty();
+
+        var salaryPaymentTypes = Enum.GetValues<SalaryPaymentType>();
+        RuleFor(x => x.AllowedPaymentTypes)
+            .ForEach(r => r.Must(s => salaryPaymentTypes.Contains(s)));
+
+        var bossTypes = Enum.GetValues<BossType>();
+        RuleFor(x => x.BossTypes)
+            .ForEach(r => r.Must(b => bossTypes.Contains(b)));
     }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/Salary/Validators/UpdateSalaryRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/Salary/Validators/UpdateSalaryRequestValidator.cs
@@ -8,6 +8,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.Salary.Validators
 /// </summary>
 public class UpdateSalaryRequestValidator : AbstractValidator<UpdateSalaryRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="UpdateSalaryRequestValidator"/>.
+    /// </summary>
     public UpdateSalaryRequestValidator()
     {
         RuleFor(x => x.Name).NotNull().NotEmpty();

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryExpenses/Validators/CreateSalaryExpensesRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryExpenses/Validators/CreateSalaryExpensesRequestValidator.cs
@@ -10,6 +10,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryExpenses.Va
 /// </summary>
 public class CreateSalaryExpensesRequestValidator : AbstractValidator<CreateSalaryExpensesRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="CreateSalaryExpensesRequestValidator"/>.
+    /// </summary>
     public CreateSalaryExpensesRequestValidator()
     {
         var salaryExpenseTypes = Enum.GetValues<SalaryExpensesType>();

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryExpenses/Validators/UpdateSalaryExpensesRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryExpenses/Validators/UpdateSalaryExpensesRequestValidator.cs
@@ -8,6 +8,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryExpenses.Va
 /// </summary>
 public class UpdateSalaryExpensesRequestValidator : AbstractValidator<UpdateSalaryExpensesRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="UpdateSalaryExpensesRequestValidator"/>.
+    /// </summary>
     public UpdateSalaryExpensesRequestValidator()
     {
         RuleFor(x => x.Percentage)

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/CreateSalaryGuildLeaderRequest.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/CreateSalaryGuildLeaderRequest.cs
@@ -3,10 +3,8 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader
 /// <summary>
 ///     Запрос на создание новой записи о доле руководства гильдии в зарплатном периоде.
 /// </summary>
-/// <param name="LootId">Идентификатор предмета лута.</param>
+/// <param name="SalaryLootId">Идентификатор предмета добытого лута в зарплатном периоде.</param>
 /// <param name="Quantity">Количество предметов.</param>
-/// <param name="PricePerItem">Цена за единицу лута.</param>
 public record CreateSalaryGuildLeaderRequest(
-    int LootId,
-    int Quantity,
-    decimal PricePerItem);
+    long SalaryLootId,
+    int Quantity);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/FillByRaidsRequest.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/FillByRaidsRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader;
+
+/// <summary>
+///     Запрос на автоматическое заполнение проданного лута зарплатного периода на основе данных из рейдов.
+/// </summary>
+/// <param name="LootIds">Список идентификаторов предметов лута для автоматического заполнения.</param>
+public record FillByRaidsRequest(
+    IList<int> LootIds);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/UpdateSalaryGuildLeaderRequest.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/UpdateSalaryGuildLeaderRequest.cs
@@ -3,10 +3,6 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader
 /// <summary>
 ///     Запрос на обновление информации о доле руководства гильдии в зарплатном периоде.
 /// </summary>
-/// <param name="LootId">Идентификатор предмета лута.</param>
 /// <param name="Quantity">Количество предметов.</param>
-/// <param name="PricePerItem">Цена за единицу лута.</param>
 public record UpdateSalaryGuildLeaderRequest(
-    int LootId,
-    int Quantity,
-    decimal PricePerItem);
+    int Quantity);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/CreateSalaryGuildLeaderRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/CreateSalaryGuildLeaderRequestValidator.cs
@@ -8,6 +8,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader
 /// </summary>
 public class CreateSalaryGuildLeaderRequestValidator : AbstractValidator<CreateSalaryGuildLeaderRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="CreateSalaryGuildLeaderRequestValidator"/>.
+    /// </summary>
     public CreateSalaryGuildLeaderRequestValidator()
     {
         RuleFor(x => x.LootId).GreaterThan(0);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/CreateSalaryGuildLeaderRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/CreateSalaryGuildLeaderRequestValidator.cs
@@ -13,8 +13,7 @@ public class CreateSalaryGuildLeaderRequestValidator : AbstractValidator<CreateS
     /// </summary>
     public CreateSalaryGuildLeaderRequestValidator()
     {
-        RuleFor(x => x.LootId).GreaterThan(0);
+        RuleFor(x => x.SalaryLootId).GreaterThan(0);
         RuleFor(x => x.Quantity).GreaterThan(0);
-        RuleFor(x => x.PricePerItem).GreaterThan(0);
     }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/FillByRaidsRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/FillByRaidsRequestValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+
+namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader.Validators;
+
+/// <summary>
+///     Валидатор для запроса <see cref="FillByRaidsRequest"/>.
+/// </summary>
+public class FillByRaidsRequestValidator : AbstractValidator<FillByRaidsRequest>
+{
+    /// <summary>
+    ///     Инициализирует новый экземпляр класса <see cref="FillByRaidsRequestValidator"/> и настраивает правила валидации.
+    /// </summary>
+    public FillByRaidsRequestValidator()
+    {
+        RuleFor(x => x.LootIds).NotEmpty();
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/UpdateSalaryGuildLeaderRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/UpdateSalaryGuildLeaderRequestValidator.cs
@@ -13,8 +13,6 @@ public class UpdateSalaryGuildLeaderRequestValidator : AbstractValidator<UpdateS
     /// </summary>
     public UpdateSalaryGuildLeaderRequestValidator()
     {
-        RuleFor(x => x.LootId).GreaterThan(0);
         RuleFor(x => x.Quantity).GreaterThan(0);
-        RuleFor(x => x.PricePerItem).GreaterThan(0);
     }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/UpdateSalaryGuildLeaderRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryGuildLeader/Validators/UpdateSalaryGuildLeaderRequestValidator.cs
@@ -8,6 +8,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader
 /// </summary>
 public class UpdateSalaryGuildLeaderRequestValidator : AbstractValidator<UpdateSalaryGuildLeaderRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="UpdateSalaryGuildLeaderRequestValidator"/>.
+    /// </summary>
     public UpdateSalaryGuildLeaderRequestValidator()
     {
         RuleFor(x => x.LootId).GreaterThan(0);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryLoot/Validators/CreateSalaryLootRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryLoot/Validators/CreateSalaryLootRequestValidator.cs
@@ -9,6 +9,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryLoot.Valida
 /// </summary>
 public class CreateSalaryLootRequestValidator : AbstractValidator<CreateSalaryLootRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="CreateSalaryLootRequestValidator"/>.
+    /// </summary>
     public CreateSalaryLootRequestValidator()
     {
         RuleFor(x => x.LootId).GreaterThan(0);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryLoot/Validators/UpdateSalaryLootRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryLoot/Validators/UpdateSalaryLootRequestValidator.cs
@@ -9,6 +9,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryLoot.Valida
 /// </summary>
 public class UpdateSalaryLootRequestValidator : AbstractValidator<UpdateSalaryLootRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="UpdateSalaryLootRequestValidator"/>.
+    /// </summary>
     public UpdateSalaryLootRequestValidator()
     {
         RuleFor(x => x.LootId).GreaterThan(0);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryMember/Validators/CreateSalaryMemberAdminRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryMember/Validators/CreateSalaryMemberAdminRequestValidator.cs
@@ -9,6 +9,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryMember.Vali
 /// </summary>
 public class CreateSalaryMemberAdminRequestValidator : AbstractValidator<CreateSalaryMemberAdminRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="CreateSalaryMemberAdminRequestValidator"/>.
+    /// </summary>
     public CreateSalaryMemberAdminRequestValidator()
     {
         RuleFor(x => x.UserId).NotNull().NotEmpty();

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryMember/Validators/CreateSalaryMemberRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryMember/Validators/CreateSalaryMemberRequestValidator.cs
@@ -9,6 +9,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryMember.Vali
 /// </summary>
 public class CreateSalaryMemberRequestValidator : AbstractValidator<CreateSalaryMemberRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="CreateSalaryMemberRequestValidator"/>.
+    /// </summary>
     public CreateSalaryMemberRequestValidator()
     {
         var salaryPaymentTypes = Enum.GetValues<SalaryPaymentType>();

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryMember/Validators/UpdateSalaryMemberRequestValidator.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Requests/SalarySummary/SalaryMember/Validators/UpdateSalaryMemberRequestValidator.cs
@@ -9,6 +9,9 @@ namespace Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryMember.Vali
 /// </summary>
 public class UpdateSalaryMemberRequestValidator : AbstractValidator<UpdateSalaryMemberRequest>
 {
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="UpdateSalaryMemberRequestValidator"/>.
+    /// </summary>
     public UpdateSalaryMemberRequestValidator()
     {
         var salaryPaymentTypes = Enum.GetValues<SalaryPaymentType>();

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Controllers/SalarySummary/SalaryGuildLeaderController.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Controllers/SalarySummary/SalaryGuildLeaderController.cs
@@ -58,26 +58,26 @@ public class SalaryGuildLeaderController : ControllerBase
     ///     Amount пересчитывается по формуле: Quantity * PricePerLoot.
     /// </summary>
     /// <param name="salaryId">Идентификатор зарплатного периода.</param>
-    /// <param name="guildLeaderId">Идентификатор записи доли руководства гильдии.</param>
+    /// <param name="salaryLootId">Идентификатор записи лута зарплатного периода.</param>
     /// <param name="request">Обновлённые данные о доле руководства гильдии.</param>
     /// <returns>Информация об обновлённой доле руководства гильдии.</returns>
     [RequireRoles(UserRole.Admin, UserRole.GuildLeader)]
-    [HttpPut("{guildLeaderId:long}")]
-    public Task<SalaryGuildLeaderDto> UpdateAsync([FromRoute] long salaryId, [FromRoute] long guildLeaderId, [FromBody] UpdateSalaryGuildLeaderRequest request)
+    [HttpPut("{salaryLootId:long}")]
+    public Task<SalaryGuildLeaderDto> UpdateAsync([FromRoute] long salaryId, [FromRoute] long salaryLootId, [FromBody] UpdateSalaryGuildLeaderRequest request)
     {
-        return _service.UpdateAsync(salaryId, guildLeaderId, request);
+        return _service.UpdateAsync(salaryId, salaryLootId, request);
     }
 
     /// <summary>
     ///     Удаляет запись о доле руководства гильдии из указанного зарплатного периода.
     /// </summary>
     /// <param name="salaryId">Идентификатор зарплатного периода.</param>
-    /// <param name="guildLeaderId">Идентификатор записи доли руководства гильдии.</param>
+    /// <param name="salaryLootId">Идентификатор записи лута зарплатного периода.</param>
     /// <returns>Результат выполнения операции.</returns>
     [RequireRoles(UserRole.Admin, UserRole.GuildLeader)]
-    [HttpDelete("{guildLeaderId:long}")]
-    public Task DeleteAsync([FromRoute] long salaryId, [FromRoute] long guildLeaderId)
+    [HttpDelete("{salaryLootId:long}")]
+    public Task DeleteAsync([FromRoute] long salaryId, [FromRoute] long salaryLootId)
     {
-        return _service.DeleteAsync(salaryId, guildLeaderId);
+        return _service.DeleteAsync(salaryId, salaryLootId);
     }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Controllers/SalarySummary/SalaryLootController.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Controllers/SalarySummary/SalaryLootController.cs
@@ -1,5 +1,6 @@
 using Freaks.Portal.Bll.Interfaces.SalarySummary;
 using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+using Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryGuildLeader;
 using Freaks.Portal.SharedContracts.Requests.SalarySummary.SalaryLoot;
 using Freaks.Users.Common.Attributes;
 using Freaks.Users.Contracts.ValueObjects;
@@ -51,6 +52,19 @@ public class SalaryLootController : ControllerBase
     public Task<SalaryLootDto> CreateAsync([FromRoute] long salaryId, [FromBody] CreateSalaryLootRequest request)
     {
         return _service.CreateAsync(salaryId, request);
+    }
+
+    /// <summary>
+    ///     Автоматически заполняет проданный лут зарплатного периода на основе данных из рейдов.
+    ///     Удаляет все существующие записи лута за период и создаёт новые на основе указанных предметов из рейдов.
+    /// </summary>
+    /// <param name="salaryId">Идентификатор зарплатного периода.</param>
+    /// <param name="request">Запрос с идентификаторами предметов лута для автоматического заполнения.</param>
+    [RequireRoles(UserRole.Admin, UserRole.GuildLeader)]
+    [HttpPost("fill-by-raids")]
+    public Task FillByRaidsAsync([FromRoute] long salaryId, [FromBody] FillByRaidsRequest request)
+    {
+        return _service.FillByRaidsAsync(salaryId, request);
     }
 
     /// <summary>

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Program.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Program.cs
@@ -1,12 +1,7 @@
-using System.Reflection;
-using FluentValidation;
-using Freaks.Bll.Common.Extensions;
 using Freaks.Dal.Common.Extensions;
-using Freaks.Messages.Common;
 using Freaks.Portal.Bll.Implementation;
 using Freaks.Portal.Dal.Implementation;
 using Freaks.Portal.Dal.Persistence;
-using Freaks.Portal.SharedContracts.Requests.SalarySummary.Salary;
 using Freaks.Portal.SharedContracts.Requests.SalarySummary.Salary.Validators;
 using Freaks.Users.Common;
 using Freaks.Users.Dal.Persistence;
@@ -20,14 +15,9 @@ builder.Services.AddControllers();
 builder.Services.AddDefaults(builder.Configuration);
 builder.Services.AddValidation(typeof(CreateSalaryRequestValidator).Assembly);
 builder.Services.AddNSwag();
-builder.Services.AddMapsterCommon();
-builder.Services.AddCentrifugoMessageService(builder.Configuration);
 
 // Auth
 builder.Services.AddKeycloakAuth(builder.Configuration);
-
-// Cache
-builder.Services.AddEasyCachingCommon(builder.Configuration);
 
 // User
 builder.Services.AddUserContext(builder.Configuration);

--- a/src/backend/dotnet/Shared/Freaks.Bll.Common/Extensions/MapperExtensions.cs
+++ b/src/backend/dotnet/Shared/Freaks.Bll.Common/Extensions/MapperExtensions.cs
@@ -1,6 +1,9 @@
-﻿using Mapster;
+﻿using System.Reflection;
+using FastExpressionCompiler;
+using Mapster;
 using MapsterMapper;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Freaks.Bll.Common.Extensions;
 
@@ -14,9 +17,16 @@ public static class MapperExtensions
     ///     и регистрирует <see cref="TypeAdapterConfig" /> и <see cref="IMapper" />.
     /// </summary>
     /// <param name="services">Коллекция сервисов для регистрации.</param>
-    public static IServiceCollection AddMapsterCommon(this IServiceCollection services)
+    /// <param name="assembly">Сборка приложения, в которой находятся конфиги</param>
+    public static IServiceCollection AddMapsterCommon(this IServiceCollection services, Assembly assembly)
     {
-        services.AddMapster();
+        var config = TypeAdapterConfig.GlobalSettings;
+
+        config.Compiler = exp => exp.CompileFast();
+        config.Scan(assembly);
+
+        services.AddSingleton(config);
+        services.TryAddScoped<IMapper, ServiceMapper>();
 
         return services;
     }

--- a/src/backend/dotnet/Shared/Freaks.Bll.Common/Freaks.Bll.Common.csproj
+++ b/src/backend/dotnet/Shared/Freaks.Bll.Common/Freaks.Bll.Common.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FastExpressionCompiler" Version="5.3.0" />
         <PackageReference Include="Hangfire.AspNetCore" Version="1.8.22" />
         <PackageReference Include="Hangfire.PostgreSql" Version="1.20.13" />
         <PackageReference Include="Mapster" Version="7.4.0"/>

--- a/src/backend/dotnet/Shared/Freaks.Dal.Common/Extensions/CacheExtensions.cs
+++ b/src/backend/dotnet/Shared/Freaks.Dal.Common/Extensions/CacheExtensions.cs
@@ -4,6 +4,7 @@ using Freaks.Dal.Common.Interfaces;
 using Freaks.Options.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Freaks.Dal.Common.Extensions;
 
@@ -65,7 +66,7 @@ public static class CacheExtensions
             //     "hybrid");
         });
 
-        services.AddScoped<ICacheProvider, EasyCacheProvider>();
+        services.TryAddScoped<ICacheProvider, EasyCacheProvider>();
 
         return services;
     }

--- a/src/backend/dotnet/Shared/Freaks.Dal.Common/Implementations/BaseProvider.cs
+++ b/src/backend/dotnet/Shared/Freaks.Dal.Common/Implementations/BaseProvider.cs
@@ -53,8 +53,7 @@ public abstract class BaseProvider<TEntity, TKey, TDbContext> : IBaseProvider<TE
         var entry = await Set.AddAsync(entity);
         await DbContext.SaveChangesAsync();
 
-        var result = await GetAsync(entry.Entity.Id, EntityTrackingType.NoTracking);
-        return result!;
+        return (await GetAsync(entry.Entity.Id, EntityTrackingType.NoTracking))!;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
refactor: update salary_guild_leader schema and relationships
- Dropped unused columns (`amount`, `loot_id`, `price_per_item`) in `salary_guild_leader`.
- Renamed `id` to `salary_loot_id`.
- Updated schema relationships with `salary_loot` table, including foreign key adjustments.
- Truncated salary-related tables to maintain data consistency during migration.

feat: add support for auto-filling salary loot from raids
- Introduced `FillByRaidsAsync` method in `ISalaryLootService` to fill sold loot data automatically based on raid details.
- Added `DeleteBySalaryIdAsync` method in `ISalaryLootProvider` to clear existing loot data for a given salary period.
- Implemented `FillByRaidsRequest` and associated FluentValidation validator to handle request structure and validation.
- Updated `SalaryLootController` with a new `fill-by-raids` endpoint.