### PR TITLE
feat: integrate OpenTelemetry and NLog for enhanced logging and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ target
 nul
 .zed
 .claude
+config.alloy

--- a/docker/GrafanaAlloy/config.alloy.template
+++ b/docker/GrafanaAlloy/config.alloy.template
@@ -1,0 +1,94 @@
+// Grafana Alloy configuration for receiving logs and forwarding to Grafana Cloud Loki
+
+// Принимаем логи по Loki HTTP API на порту 3100
+loki.source.api "default" {
+  http {
+    listen_address = "0.0.0.0"
+    listen_port    = 3100
+  }
+
+  // Пересылаем все логи в Grafana Cloud
+  forward_to = [loki.write.grafanacloud.receiver]
+
+  // Добавляем метку источника
+  labels = {
+    source = "alloy",
+  }
+}
+
+// Отправляем логи в Grafana Cloud Loki
+loki.write "grafanacloud" {
+  endpoint {
+    url = "your_loki_url"
+
+    basic_auth {
+      username = "your_loki_username"
+      password = "your_loki_password"
+    }
+  }
+
+  // Параметры отправки
+  external_labels = {
+    cluster = "freaks-aa",
+  }
+}
+
+// Принимаем метрики от .NET сервисов по OTLP и конвертируем в Prometheus формат
+otelcol.receiver.otlp "freaks" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    metrics = [otelcol.exporter.prometheus.freaks.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+
+otelcol.exporter.prometheus "freaks" {
+  forward_to = [prometheus.remote_write.grafanacloud.receiver]
+}
+
+// Отправляем трейсы в Grafana Cloud Tempo
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "your_otlp_url"
+    auth     = otelcol.auth.basic.tempo.handler
+  }
+}
+
+otelcol.auth.basic "tempo" {
+  username = "your_tempo_username"
+  password = "your_tempo_password"
+}
+
+// Экспорт метрик самого Alloy
+prometheus.exporter.self "alloy" { }
+
+prometheus.scrape "alloy_metrics" {
+  targets    = prometheus.exporter.self.alloy.targets
+  forward_to = [prometheus.remote_write.grafanacloud.receiver]
+}
+
+prometheus.remote_write "grafanacloud" {
+  endpoint {
+    url = "your_prometheus_url"
+
+    basic_auth {
+      username = "your_prometheus_username"
+      password = "your_prometheus_password"
+    }
+  }
+
+  external_labels = {
+    cluster = "freaks-aa",
+  }
+}
+
+// Логирование для отладки Alloy
+logging {
+  level  = "info"
+  format = "logfmt"
+}

--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -15,6 +15,8 @@ services:
       - KeycloakAdmin__resource=realm_admin
       - KeycloakAdmin__credentials__secret=${KEYCLOAK_ADMIN_CLIENT_SECRET}
       - DbOptions__ConnectionString=${DB_OPTIONS}
+      - OpenTelemetry__OtlpEndpoint=http://alloy:4318
+      - NLog__targets__loki__endpoint=http://alloy:3100
     depends_on:
       - rabbitmq
       - redis
@@ -33,6 +35,8 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Compose
       - DbOptions__ConnectionString=${DB_OPTIONS}
+      - OpenTelemetry__OtlpEndpoint=http://alloy:4318
+      - NLog__targets__loki__endpoint=http://alloy:3100
       - StorageOptions__Host=${STORAGE_OPTIONS_HOST}
       - StorageOptions__AccessKey=${STORAGE_OPTIONS_ACCESS_KEY}
       - StorageOptions__SecretKey=${STORAGE_OPTIONS_SECRET_KEY}
@@ -66,8 +70,6 @@ services:
         - RABBITMQ_VERSION=${RABBITMQ_VERSION}
     ports:
       - "18672:15672"
-      - "8672:5672"
-      - "8671:5671"
       - "18671:15671"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq:rw
@@ -93,7 +95,24 @@ services:
       nofile:
         soft: 65535
         hard: 65535
+  alloy:
+    image: grafana/alloy:latest
+    container_name: grafana-alloy
+    restart: unless-stopped
+    ports:
+      - "12345:12345"  # Alloy UI
+    volumes:
+      - ./GrafanaLoki/config.alloy:/etc/alloy/config.alloy:ro
+      - alloy-data:/var/lib/alloy
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy
+      - /etc/alloy/config.alloy
+    environment:
+      - HOSTNAME=alloy
 volumes:
   postgres_data: null
   minio_data: null
   rabbitmq_data: null
+  alloy-data: null

--- a/docker/setup-env.cmd
+++ b/docker/setup-env.cmd
@@ -24,4 +24,32 @@ echo Updating .env file...
 move /Y temp_env .env >nul
 
 echo Done! .env file is updated.
+
+echo.
+echo === Grafana Alloy Configuration ===
+echo.
+
+echo --- Loki (logs) ---
+set /p LOKI_URL="Loki URL: "
+set /p LOKI_USERNAME="Loki username: "
+set /p LOKI_PASSWORD="Loki password: "
+
+echo.
+echo --- Tempo (traces) ---
+set /p TEMPO_URL="Tempo OTLP endpoint: "
+set /p TEMPO_USERNAME="Tempo username: "
+set /p TEMPO_PASSWORD="Tempo password: "
+
+echo.
+echo --- Prometheus (metrics) ---
+set /p PROMETHEUS_URL="Prometheus remote write URL: "
+set /p PROMETHEUS_USERNAME="Prometheus username: "
+set /p PROMETHEUS_PASSWORD="Prometheus password: "
+
+echo.
+echo Generating GrafanaAlloy\config.alloy from template...
+
+powershell -NoProfile -Command "$c = [IO.File]::ReadAllText('GrafanaAlloy\config.alloy.template'); $c = $c.Replace('your_loki_url',$env:LOKI_URL).Replace('your_loki_username',$env:LOKI_USERNAME).Replace('your_loki_password',$env:LOKI_PASSWORD).Replace('your_otlp_url',$env:TEMPO_URL).Replace('your_tempo_username',$env:TEMPO_USERNAME).Replace('your_tempo_password',$env:TEMPO_PASSWORD).Replace('your_prometheus_url',$env:PROMETHEUS_URL).Replace('your_prometheus_username',$env:PROMETHEUS_USERNAME).Replace('your_prometheus_password',$env:PROMETHEUS_PASSWORD); [IO.File]::WriteAllText('GrafanaAlloy\config.alloy',$c)"
+
+echo Done! GrafanaAlloy\config.alloy is generated.
 pause

--- a/docker/setup-env.sh
+++ b/docker/setup-env.sh
@@ -24,3 +24,41 @@ done < .env
 mv "$temp_file" .env
 
 echo "Done! .env file is updated."
+
+# === Grafana Alloy Configuration ===
+echo ""
+echo "=== Grafana Alloy Configuration ==="
+echo ""
+
+echo "--- Loki (logs) ---"
+read -rp "Loki URL: " loki_url
+read -rp "Loki username: " loki_username
+read -rp "Loki password: " loki_password
+
+echo ""
+echo "--- Tempo (traces) ---"
+read -rp "Tempo OTLP endpoint: " tempo_url
+read -rp "Tempo username: " tempo_username
+read -rp "Tempo password: " tempo_password
+
+echo ""
+echo "--- Prometheus (metrics) ---"
+read -rp "Prometheus remote write URL: " prometheus_url
+read -rp "Prometheus username: " prometheus_username
+read -rp "Prometheus password: " prometheus_password
+
+echo ""
+echo "Generating GrafanaAlloy/config.alloy from template..."
+
+sed -e "s|your_loki_url|$loki_url|g" \
+    -e "s|your_loki_username|$loki_username|g" \
+    -e "s|your_loki_password|$loki_password|g" \
+    -e "s|your_otlp_url|$tempo_url|g" \
+    -e "s|your_tempo_username|$tempo_username|g" \
+    -e "s|your_tempo_password|$tempo_password|g" \
+    -e "s|your_prometheus_url|$prometheus_url|g" \
+    -e "s|your_prometheus_username|$prometheus_username|g" \
+    -e "s|your_prometheus_password|$prometheus_password|g" \
+    GrafanaAlloy/config.alloy.template > GrafanaAlloy/config.alloy
+
+echo "Done! GrafanaAlloy/config.alloy is generated."

--- a/src/backend/dotnet/Freaks.slnx
+++ b/src/backend/dotnet/Freaks.slnx
@@ -61,6 +61,7 @@
     <Project Path="Shared/Freaks.Dal.Common/Freaks.Dal.Common.csproj" />
     <Project Path="Shared/Freaks.Options.Common/Freaks.Options.Common.csproj" />
     <Project Path="Shared/Freaks.SharedContracts.Common/Freaks.SharedContracts.Common.csproj" />
+    <Project Path="Shared/Freaks.Telemetry.Common/Freaks.Telemetry.Common.csproj" />
     <Project Path="Shared/Freaks.WebApi.Common/Freaks.WebApi.Common.csproj" />
   </Folder>
   <Folder Name="/Shared/Messages/">

--- a/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/Freaks.Bots.DiscordBot.WebApi.csproj
+++ b/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/Freaks.Bots.DiscordBot.WebApi.csproj
@@ -11,4 +11,8 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\Shared\Freaks.Telemetry.Common\Freaks.Telemetry.Common.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/Program.cs
+++ b/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/Program.cs
@@ -1,3 +1,5 @@
+using Freaks.Telemetry.Common.Extensions;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -5,6 +7,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.AddNLogCommon();
+builder.Services.AddMetricsAndTraces(builder.Environment, builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/appsettings.Development.json
+++ b/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4318"
   }
 }

--- a/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/appsettings.Staging.json
+++ b/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/appsettings.Staging.json
@@ -1,0 +1,3 @@
+{
+  "LokiMinLevel": "Info"
+}

--- a/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/appsettings.json
+++ b/src/backend/dotnet/Services/Bots/DiscordBot/Freaks.Bots.DiscordBot.WebApi/appsettings.json
@@ -2,8 +2,83 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient.OtlpTraceExporter": "Error",
+      "System.Net.Http.HttpClient.OtlpMetricExporter": "Error"
+    },
+    "NLog": {
+      "IncludeScopes": true,
+      "RemoveLoggerFactoryFilter": false
     }
+  },
+  "NLog": {
+    "throwConfigExceptions": true,
+    "internalLogLevel": "Trace",
+    "internalLogToConsole": true,
+    "internalLogFile": "logs/nlog-internal.log",
+    "extensions": [
+      { "assembly": "NLog.Loki" },
+      { "assembly": "NLog.DiagnosticSource" }
+    ],
+    "targets": {
+      "console": {
+        "type": "coloredConsole",
+        "useDefaultRowHighlightingRules": false,
+        "layout": "${date:format=HH\\:mm\\:ss.fff:universalTime=true}|${level:uppercase=true:padding=5}|${pad:padding=-35:fixedLength=true:inner=${logger:shortName=true}}|${indent-message}${when:when='${activity:property=TraceId}' != '':inner= # ${activity:property=TraceId}}${onexception:inner=${newline}  -> ${exception:format=shortType,message}${newline}${exception:format=stackTrace:separator=\\n}}",
+        "rowHighlightingRules": [
+          { "condition": "level == LogLevel.Trace", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Debug", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Info", "foregroundColor": "White" },
+          { "condition": "level == LogLevel.Warn", "foregroundColor": "Yellow" },
+          { "condition": "level == LogLevel.Error", "foregroundColor": "Red" },
+          { "condition": "level == LogLevel.Fatal", "foregroundColor": "White", "backgroundColor": "DarkRed" }
+        ],
+        "wordHighlightingRules": [
+          { "text": "| INFO|", "foregroundColor": "Green" },
+          { "text": "| WARN|", "foregroundColor": "Yellow" },
+          { "text": "|ERROR|", "foregroundColor": "Red" },
+          { "text": "|DEBUG|", "foregroundColor": "DarkGray" },
+          { "text": "|FATAL|", "foregroundColor": "Magenta" },
+          { "text": "|TRACE|", "foregroundColor": "DarkGray" },
+          { "text": "#", "foregroundColor": "DarkYellow" }
+        ]
+      },
+      "loki": {
+        "type": "loki",
+        "endpoint": "http://localhost:3100",
+        "batchSize": 100,
+        "taskDelayMilliseconds": 2000,
+        "compressionLevel": "optimal",
+        "orderWrites": true,
+        "labels": [
+          { "name": "app", "layout": "freaks-discord-bot-api" },
+          { "name": "environment", "layout": "${environment:variable=ASPNETCORE_ENVIRONMENT:default=Production}" },
+          { "name": "level", "layout": "${level:lowercase=true}" },
+          { "name": "hostname", "layout": "${hostname:lowercase=true}" }
+        ],
+        "layout": {
+          "type": "JsonLayout",
+          "attributes": [
+            { "name": "timestamp", "layout": "${longdate:universalTime=true}" },
+            { "name": "level", "layout": "${level:uppercase=true}" },
+            { "name": "logger", "layout": "${logger}" },
+            { "name": "message", "layout": "${message}" },
+            { "name": "exception", "layout": "${exception:format=ToString}" },
+            { "name": "callsite", "layout": "${callsite:includeNamespace=false}" },
+            { "name": "threadid", "layout": "${threadid}" },
+            { "name": "traceID", "layout": "${activity:property=TraceId}" },
+            { "name": "spanID", "layout": "${activity:property=SpanId}" },
+            { "name": "username", "layout": "${aspnet-user-identity}" },
+            { "name": "userEmail", "layout": "${aspnet-user-claim:ClaimType=email}" },
+            { "name": "userSub", "layout": "${aspnet-user-claim:ClaimType=sub}" }
+          ]
+        }
+      }
+    },
+    "rules": [
+      { "logger": "*", "minLevel": "Info", "writeTo": "console" },
+      { "logger": "*", "minLevel": "${configsetting:LokiMinLevel:whenEmpty=Off}", "writeTo": "loki" }
+    ]
   },
   "AllowedHosts": "*"
 }

--- a/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/Freaks.Bots.TelegramBot.WebApi.csproj
+++ b/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/Freaks.Bots.TelegramBot.WebApi.csproj
@@ -11,4 +11,8 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\Shared\Freaks.Telemetry.Common\Freaks.Telemetry.Common.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/Program.cs
+++ b/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/Program.cs
@@ -1,3 +1,5 @@
+using Freaks.Telemetry.Common.Extensions;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -5,6 +7,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.AddNLogCommon();
+builder.Services.AddMetricsAndTraces(builder.Environment, builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/appsettings.Development.json
+++ b/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4318"
   }
 }

--- a/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/appsettings.Staging.json
+++ b/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/appsettings.Staging.json
@@ -1,0 +1,3 @@
+{
+  "LokiMinLevel": "Info"
+}

--- a/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/appsettings.json
+++ b/src/backend/dotnet/Services/Bots/TelegramBot/Freaks.Bots.TelegramBot.WebApi/appsettings.json
@@ -2,8 +2,83 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient.OtlpTraceExporter": "Error",
+      "System.Net.Http.HttpClient.OtlpMetricExporter": "Error"
+    },
+    "NLog": {
+      "IncludeScopes": true,
+      "RemoveLoggerFactoryFilter": false
     }
+  },
+  "NLog": {
+    "throwConfigExceptions": true,
+    "internalLogLevel": "Trace",
+    "internalLogToConsole": true,
+    "internalLogFile": "logs/nlog-internal.log",
+    "extensions": [
+      { "assembly": "NLog.Loki" },
+      { "assembly": "NLog.DiagnosticSource" }
+    ],
+    "targets": {
+      "console": {
+        "type": "coloredConsole",
+        "useDefaultRowHighlightingRules": false,
+        "layout": "${date:format=HH\\:mm\\:ss.fff:universalTime=true}|${level:uppercase=true:padding=5}|${pad:padding=-35:fixedLength=true:inner=${logger:shortName=true}}|${indent-message}${when:when='${activity:property=TraceId}' != '':inner= # ${activity:property=TraceId}}${onexception:inner=${newline}  -> ${exception:format=shortType,message}${newline}${exception:format=stackTrace:separator=\\n}}",
+        "rowHighlightingRules": [
+          { "condition": "level == LogLevel.Trace", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Debug", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Info", "foregroundColor": "White" },
+          { "condition": "level == LogLevel.Warn", "foregroundColor": "Yellow" },
+          { "condition": "level == LogLevel.Error", "foregroundColor": "Red" },
+          { "condition": "level == LogLevel.Fatal", "foregroundColor": "White", "backgroundColor": "DarkRed" }
+        ],
+        "wordHighlightingRules": [
+          { "text": "| INFO|", "foregroundColor": "Green" },
+          { "text": "| WARN|", "foregroundColor": "Yellow" },
+          { "text": "|ERROR|", "foregroundColor": "Red" },
+          { "text": "|DEBUG|", "foregroundColor": "DarkGray" },
+          { "text": "|FATAL|", "foregroundColor": "Magenta" },
+          { "text": "|TRACE|", "foregroundColor": "DarkGray" },
+          { "text": "#", "foregroundColor": "DarkYellow" }
+        ]
+      },
+      "loki": {
+        "type": "loki",
+        "endpoint": "http://localhost:3100",
+        "batchSize": 100,
+        "taskDelayMilliseconds": 2000,
+        "compressionLevel": "optimal",
+        "orderWrites": true,
+        "labels": [
+          { "name": "app", "layout": "freaks-telegram-bot-api" },
+          { "name": "environment", "layout": "${environment:variable=ASPNETCORE_ENVIRONMENT:default=Production}" },
+          { "name": "level", "layout": "${level:lowercase=true}" },
+          { "name": "hostname", "layout": "${hostname:lowercase=true}" }
+        ],
+        "layout": {
+          "type": "JsonLayout",
+          "attributes": [
+            { "name": "timestamp", "layout": "${longdate:universalTime=true}" },
+            { "name": "level", "layout": "${level:uppercase=true}" },
+            { "name": "logger", "layout": "${logger}" },
+            { "name": "message", "layout": "${message}" },
+            { "name": "exception", "layout": "${exception:format=ToString}" },
+            { "name": "callsite", "layout": "${callsite:includeNamespace=false}" },
+            { "name": "threadid", "layout": "${threadid}" },
+            { "name": "traceID", "layout": "${activity:property=TraceId}" },
+            { "name": "spanID", "layout": "${activity:property=SpanId}" },
+            { "name": "username", "layout": "${aspnet-user-identity}" },
+            { "name": "userEmail", "layout": "${aspnet-user-claim:ClaimType=email}" },
+            { "name": "userSub", "layout": "${aspnet-user-claim:ClaimType=sub}" }
+          ]
+        }
+      }
+    },
+    "rules": [
+      { "logger": "*", "minLevel": "Info", "writeTo": "console" },
+      { "logger": "*", "minLevel": "${configsetting:LokiMinLevel:whenEmpty=Off}", "writeTo": "loki" }
+    ]
   },
   "AllowedHosts": "*"
 }

--- a/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/Freaks.Files.WebApi.csproj
+++ b/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/Freaks.Files.WebApi.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\Shared\Freaks.Telemetry.Common\Freaks.Telemetry.Common.csproj" />
         <ProjectReference Include="..\..\..\Shared\Freaks.WebApi.Common\Freaks.WebApi.Common.csproj"/>
         <ProjectReference Include="..\..\..\Shared\Users\Freaks.Users.Common\Freaks.Users.Common.csproj"/>
         <ProjectReference Include="..\Bll\Freaks.Files.Bll.Implementation\Freaks.Files.Bll.Implementation.csproj"/>

--- a/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/Program.cs
+++ b/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Freaks.Dal.Common.Extensions;
 using Freaks.Files.Bll.Implementation;
 using Freaks.Files.Dal.Implementation;
+using Freaks.Telemetry.Common.Extensions;
 using Freaks.Users.Common;
 using Freaks.WebApi.Common.Extensions;
 using Mapster;
@@ -11,6 +12,8 @@ builder.Services.AddDefaults(builder.Configuration);
 builder.Services.AddControllers();
 builder.Services.AddNSwag();
 builder.Services.AddMapster();
+builder.AddNLogCommon();
+builder.Services.AddMetricsAndTraces(builder.Environment, builder.Configuration);
 
 builder.Services.AddEasyCachingCommon(builder.Configuration);
 

--- a/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.Compose.json
+++ b/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.Compose.json
@@ -1,4 +1,5 @@
 {
+  "LokiMinLevel": "Info",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.Development.json
+++ b/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.Development.json
@@ -61,5 +61,8 @@
       "Content-Disposition"
     ],
     "AllowCredentials": false
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4318"
   }
 }

--- a/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.Staging.json
+++ b/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.Staging.json
@@ -1,4 +1,5 @@
 {
+  "LokiMinLevel": "Info",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.json
+++ b/src/backend/dotnet/Services/Files/Freaks.Files.WebApi/appsettings.json
@@ -2,8 +2,83 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient.OtlpTraceExporter": "Error",
+      "System.Net.Http.HttpClient.OtlpMetricExporter": "Error"
+    },
+    "NLog": {
+      "IncludeScopes": true,
+      "RemoveLoggerFactoryFilter": false
     }
+  },
+  "NLog": {
+    "throwConfigExceptions": true,
+    "internalLogLevel": "Trace",
+    "internalLogToConsole": true,
+    "internalLogFile": "logs/nlog-internal.log",
+    "extensions": [
+      { "assembly": "NLog.Loki" },
+      { "assembly": "NLog.DiagnosticSource" }
+    ],
+    "targets": {
+      "console": {
+        "type": "coloredConsole",
+        "useDefaultRowHighlightingRules": false,
+        "layout": "${date:format=HH\\:mm\\:ss.fff:universalTime=true}|${level:uppercase=true:padding=5}|${pad:padding=-35:fixedLength=true:inner=${logger:shortName=true}}|${indent-message}${when:when='${activity:property=TraceId}' != '':inner= # ${activity:property=TraceId}}${onexception:inner=${newline}  -> ${exception:format=shortType,message}${newline}${exception:format=stackTrace:separator=\\n}}",
+        "rowHighlightingRules": [
+          { "condition": "level == LogLevel.Trace", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Debug", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Info", "foregroundColor": "White" },
+          { "condition": "level == LogLevel.Warn", "foregroundColor": "Yellow" },
+          { "condition": "level == LogLevel.Error", "foregroundColor": "Red" },
+          { "condition": "level == LogLevel.Fatal", "foregroundColor": "White", "backgroundColor": "DarkRed" }
+        ],
+        "wordHighlightingRules": [
+          { "text": "| INFO|", "foregroundColor": "Green" },
+          { "text": "| WARN|", "foregroundColor": "Yellow" },
+          { "text": "|ERROR|", "foregroundColor": "Red" },
+          { "text": "|DEBUG|", "foregroundColor": "DarkGray" },
+          { "text": "|FATAL|", "foregroundColor": "Magenta" },
+          { "text": "|TRACE|", "foregroundColor": "DarkGray" },
+          { "text": "#", "foregroundColor": "DarkYellow" }
+        ]
+      },
+      "loki": {
+        "type": "loki",
+        "endpoint": "http://localhost:3100",
+        "batchSize": 100,
+        "taskDelayMilliseconds": 2000,
+        "compressionLevel": "optimal",
+        "orderWrites": true,
+        "labels": [
+          { "name": "app", "layout": "freaks-files-api" },
+          { "name": "environment", "layout": "${environment:variable=ASPNETCORE_ENVIRONMENT:default=Production}" },
+          { "name": "level", "layout": "${level:lowercase=true}" },
+          { "name": "hostname", "layout": "${hostname:lowercase=true}" }
+        ],
+        "layout": {
+          "type": "JsonLayout",
+          "attributes": [
+            { "name": "timestamp", "layout": "${longdate:universalTime=true}" },
+            { "name": "level", "layout": "${level:uppercase=true}" },
+            { "name": "logger", "layout": "${logger}" },
+            { "name": "message", "layout": "${message}" },
+            { "name": "exception", "layout": "${exception:format=ToString}" },
+            { "name": "callsite", "layout": "${callsite:includeNamespace=false}" },
+            { "name": "threadid", "layout": "${threadid}" },
+            { "name": "traceID", "layout": "${activity:property=TraceId}" },
+            { "name": "spanID", "layout": "${activity:property=SpanId}" },
+            { "name": "username", "layout": "${aspnet-user-identity}" },
+            { "name": "userEmail", "layout": "${aspnet-user-claim:ClaimType=email}" },
+            { "name": "userSub", "layout": "${aspnet-user-claim:ClaimType=sub}" }
+          ]
+        }
+      }
+    },
+    "rules": [
+      { "logger": "*", "minLevel": "Info", "writeTo": "console" },
+      { "logger": "*", "minLevel": "${configsetting:LokiMinLevel:whenEmpty=Off}", "writeTo": "loki" }
+    ]
   },
   "AllowedHosts": "*"
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Freaks.Portal.WebApi.csproj
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Freaks.Portal.WebApi.csproj
@@ -18,6 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\Shared\Freaks.Telemetry.Common\Freaks.Telemetry.Common.csproj" />
         <ProjectReference Include="..\..\..\Shared\Freaks.WebApi.Common\Freaks.WebApi.Common.csproj"/>
         <ProjectReference Include="..\..\..\Shared\Messages\Freaks.Messages.Common\Freaks.Messages.Common.csproj"/>
         <ProjectReference Include="..\..\..\Shared\Users\Freaks.Users.Common\Freaks.Users.Common.csproj"/>

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Program.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Program.cs
@@ -3,6 +3,7 @@ using Freaks.Portal.Bll.Implementation;
 using Freaks.Portal.Dal.Implementation;
 using Freaks.Portal.Dal.Persistence;
 using Freaks.Portal.SharedContracts.Requests.SalarySummary.Salary.Validators;
+using Freaks.Telemetry.Common.Extensions;
 using Freaks.Users.Common;
 using Freaks.Users.Dal.Persistence;
 using Freaks.WebApi.Common.Extensions;
@@ -15,6 +16,8 @@ builder.Services.AddControllers();
 builder.Services.AddDefaults(builder.Configuration);
 builder.Services.AddValidation(typeof(CreateSalaryRequestValidator).Assembly);
 builder.Services.AddNSwag();
+builder.AddNLogCommon();
+builder.Services.AddMetricsAndTraces(builder.Environment, builder.Configuration);
 
 // Auth
 builder.Services.AddKeycloakAuth(builder.Configuration);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.Compose.json
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.Compose.json
@@ -1,4 +1,5 @@
 {
+  "LokiMinLevel": "Info",
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -57,5 +58,8 @@
       "Content-Disposition"
     ],
     "AllowCredentials": false
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4318"
   }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.Development.json
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.Development.json
@@ -57,5 +57,8 @@
       "Content-Disposition"
     ],
     "AllowCredentials": false
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4318"
   }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.Staging.json
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.Staging.json
@@ -1,4 +1,5 @@
 {
+  "LokiMinLevel": "Info",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.json
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/appsettings.json
@@ -2,8 +2,82 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient.OtlpTraceExporter": "Error",
+      "System.Net.Http.HttpClient.OtlpMetricExporter": "Error"
+    },
+    "NLog": {
+      "IncludeScopes": true,
+      "RemoveLoggerFactoryFilter": false
     }
+  },
+  "NLog": {
+    "throwConfigExceptions": true,
+    "extensions": [
+      { "assembly": "NLog.Loki" },
+      { "assembly": "NLog.Web.AspNetCore" },
+      { "assembly": "NLog.DiagnosticSource" }
+    ],
+    "targets": {
+      "console": {
+        "type": "coloredConsole",
+        "useDefaultRowHighlightingRules": false,
+        "layout": "${date:format=HH\\:mm\\:ss.fff:universalTime=true}|${level:uppercase=true:padding=5}|${pad:padding=-30:fixedLength=true:inner=${logger:shortName=true}}${indent-message}${when:when='${activity:property=TraceId}' != '':inner= # ${activity:property=TraceId}}${onexception:inner=${newline}  -> ${exception:format=shortType,message}${newline}${exception:format=stackTrace:separator=\\n}}",
+        "rowHighlightingRules": [
+          { "condition": "level == LogLevel.Trace", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Debug", "foregroundColor": "DarkGray" },
+          { "condition": "level == LogLevel.Info", "foregroundColor": "White" },
+          { "condition": "level == LogLevel.Warn", "foregroundColor": "Yellow" },
+          { "condition": "level == LogLevel.Error", "foregroundColor": "Red" },
+          { "condition": "level == LogLevel.Fatal", "foregroundColor": "White", "backgroundColor": "DarkRed" }
+        ],
+        "wordHighlightingRules": [
+          { "text": "| INFO|", "foregroundColor": "Green" },
+          { "text": "| WARN|", "foregroundColor": "Yellow" },
+          { "text": "|ERROR|", "foregroundColor": "Red" },
+          { "text": "|DEBUG|", "foregroundColor": "DarkGray" },
+          { "text": "|FATAL|", "foregroundColor": "Magenta" },
+          { "text": "|TRACE|", "foregroundColor": "DarkGray" },
+          { "text": "#", "foregroundColor": "DarkYellow" }
+        ]
+      },
+      "loki": {
+        "type": "loki",
+        "endpoint": "http://localhost:3100",
+        "batchSize": 100,
+        "taskDelayMilliseconds": 2000,
+        "compressionLevel": "optimal",
+        "orderWrites": true,
+        "labels": [
+          { "name": "app", "layout": "freaks-portal-api" },
+          { "name": "environment", "layout": "${environment:variable=ASPNETCORE_ENVIRONMENT:default=Production}" },
+          { "name": "level", "layout": "${level:lowercase=true}" },
+          { "name": "hostname", "layout": "${hostname:lowercase=true}" }
+        ],
+        "layout": {
+          "type": "JsonLayout",
+          "attributes": [
+            { "name": "timestamp", "layout": "${longdate:universalTime=true}" },
+            { "name": "level", "layout": "${level:uppercase=true}" },
+            { "name": "logger", "layout": "${logger}" },
+            { "name": "message", "layout": "${message}" },
+            { "name": "exception", "layout": "${exception:format=ToString}" },
+            { "name": "callsite", "layout": "${callsite:includeNamespace=false}" },
+            { "name": "threadid", "layout": "${threadid}" },
+            { "name": "traceID", "layout": "${activity:property=TraceId}" },
+            { "name": "spanID", "layout": "${activity:property=SpanId}" },
+            { "name": "userId", "layout": "${aspnet-user-claim:ClaimType=nameidentifier}" },
+            { "name": "username", "layout": "${aspnet-user-identity}" },
+            { "name": "gameNickname", "layout": "${aspnet-user-claim:ClaimType=game_nickname}" },
+            { "name": "roles", "layout": "${aspnet-user-claim:ClaimType=roles}" }
+          ]
+        }
+      }
+    },
+    "rules": [
+      { "logger": "*", "minLevel": "Info", "writeTo": "console" },
+      { "logger": "*", "minLevel": "${configsetting:LokiMinLevel:whenEmpty=Off}", "writeTo": "loki" }
+    ]
   },
   "AllowedHosts": "*"
 }

--- a/src/backend/dotnet/Shared/Freaks.Telemetry.Common/Extensions/NLogExtensions.cs
+++ b/src/backend/dotnet/Shared/Freaks.Telemetry.Common/Extensions/NLogExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Freaks.Telemetry.Common.LayoutRenderers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using NLog.LayoutRenderers;
+using NLog.Web;
+
+namespace Freaks.Telemetry.Common.Extensions;
+
+public static class NLogExtensions
+{
+    public static WebApplicationBuilder AddNLogCommon(this WebApplicationBuilder builder)
+    {
+        LayoutRenderer.Register<IndentedMessageLayoutRenderer>("indent-message");
+
+        builder.Logging.ClearProviders();
+        builder.Host.UseNLog();
+
+        return builder;
+    }
+}

--- a/src/backend/dotnet/Shared/Freaks.Telemetry.Common/Extensions/OpenTelemetryExtensions.cs
+++ b/src/backend/dotnet/Shared/Freaks.Telemetry.Common/Extensions/OpenTelemetryExtensions.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Freaks.Telemetry.Common.Extensions;
+
+public static class OpenTelemetryExtensions
+{
+    public static IServiceCollection AddMetricsAndTraces(this IServiceCollection services, IWebHostEnvironment environment, IConfiguration configuration)
+    {
+        var otlpEndpoint = configuration["OpenTelemetry:OtlpEndpoint"]?.TrimEnd('/');
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource
+                .AddService(serviceName: environment.ApplicationName)
+                .AddAttributes(new Dictionary<string, object>
+                {
+                    ["deployment_environment"] = environment.EnvironmentName.ToLower()
+                }))
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddProcessInstrumentation()
+                    .AddEventCountersInstrumentation()
+                    .AddNpgsqlInstrumentation();
+
+                metrics.AddOtlpExporter(options =>
+                {
+                    options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                    if (!string.IsNullOrEmpty(otlpEndpoint))
+                        options.Endpoint = new Uri($"{otlpEndpoint}/v1/metrics");
+                });
+            })
+            .WithTracing(tracing => tracing
+                .SetSampler<AlwaysOnSampler>()
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddNpgsql()
+                .AddEntityFrameworkCoreInstrumentation()
+                .AddOtlpExporter(options =>
+                {
+                    options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                    if (!string.IsNullOrEmpty(otlpEndpoint))
+                        options.Endpoint = new Uri($"{otlpEndpoint}/v1/traces");
+                }));
+
+        return services;
+    }
+}

--- a/src/backend/dotnet/Shared/Freaks.Telemetry.Common/Freaks.Telemetry.Common.csproj
+++ b/src/backend/dotnet/Shared/Freaks.Telemetry.Common/Freaks.Telemetry.Common.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NLog" Version="6.1.0" />
+        <PackageReference Include="NLog.DiagnosticSource" Version="6.0.3" />
+        <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
+        <PackageReference Include="NLog.Web" Version="6.1.1" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.1" />
+        <PackageReference Include="NLog.Targets.Loki" Version="2.4.0" />
+        <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.15.0-alpha.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/backend/dotnet/Shared/Freaks.Telemetry.Common/LayoutRenderers/IndentedMessageLayoutRenderer.cs
+++ b/src/backend/dotnet/Shared/Freaks.Telemetry.Common/LayoutRenderers/IndentedMessageLayoutRenderer.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using NLog;
+using NLog.LayoutRenderers;
+
+namespace Freaks.Telemetry.Common.LayoutRenderers;
+
+/// <summary>
+///     Выводит сообщение лога с автоматическим отступом для продолжающих строк,
+///     выравнивая их по колонке сообщения (timestamp + level + logger = 58 символов).
+/// </summary>
+[LayoutRenderer("indent-message")]
+public sealed class IndentedMessageLayoutRenderer : LayoutRenderer
+{
+    // timestamp(12) + |(1) + level(5) + |(1) + logger(35) + |(1) = 55
+    private const string Continuation = "\n                                                       ";
+
+    protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+    {
+        var message = logEvent.FormattedMessage;
+
+        if (!string.IsNullOrEmpty(message) && message.Contains('\n'))
+            builder.Append(message.Replace("\r\n", "\n").Replace("\n", Continuation));
+        else
+            builder.Append(message);
+    }
+}


### PR DESCRIPTION
- Added a shared `Freaks.Telemetry.Common` project with reusable extensions for OpenTelemetry and NLog setup.
- Integrated Loki logging and metrics tracing support in TelegramBot, DiscordBot, Portal, and Files APIs.
- Updated `appsettings.*.json` configurations to include NLog and OpenTelemetry settings.
- Extended the Docker Compose stack with Alloy for metrics and Loki for log aggregation.
- Refactored logging and metrics initialization logic across services for consistency and reusability.
- Introduced `IndentedMessageLayoutRenderer` for improved multi-line log message formatting.