### PR TITLE
feat: add `salary_final_report` table and extend `salary` schema

### DIFF
--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/ConfigureServices.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/ConfigureServices.cs
@@ -45,6 +45,7 @@ public static class ConfigureServices
         services.AddScoped<ISalaryLootService, SalaryLootService>();
         services.AddScoped<ISalaryGuildLeaderService, SalaryGuildLeaderService>();
         services.AddScoped<ISalaryExpensesService, SalaryExpensesService>();
+        services.AddScoped<ISalaryFinalReportService, SalaryFinalReportService>();
         services.AddScoped<ISalaryMemberService, SalaryMemberService>();
         services.AddScoped<ISalaryCalculationService, SalaryCalculationService>();
         services.AddScoped<ISalaryStepService, SalaryStepService>();

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Algorithms/BasicSalaryAlgorithm.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/Algorithms/BasicSalaryAlgorithm.cs
@@ -1,6 +1,7 @@
 using Freaks.Portal.Bll.Implementation.SalarySummary.Helpers;
 using Freaks.Portal.Contracts.Entities.SalarySummary;
 using Freaks.Portal.Contracts.ValueObjects.RaidSummary;
+using Freaks.Portal.Contracts.ValueObjects.SalarySummary;
 using Freaks.Portal.SharedContracts.ValueObjects.Loot;
 using Freaks.Portal.SharedContracts.ValueObjects.RaidSummary;
 using Freaks.Portal.SharedContracts.ValueObjects.SalarySummary;
@@ -14,12 +15,12 @@ namespace Freaks.Portal.Bll.Implementation.SalarySummary.Algorithms;
 /// </summary>
 public class BasicSalaryAlgorithm
 {
-    private readonly Salary _salary;
-    private readonly IList<SalaryLoot> _loot;
-    private readonly IList<SalaryGuildLeader> _guildLeader;
-    private readonly IList<SalaryExpenses> _expenses;
-    private readonly IList<SalaryMember> _members;
-    private readonly IList<RaidFullInfo> _raids;
+    private Salary _salary;
+    private IList<SalaryLoot> _loot;
+    private IList<SalaryGuildLeader> _guildLeader;
+    private IList<SalaryExpenses> _expenses;
+    private IList<SalaryMember> _members;
+    private IList<RaidFullInfo> _raids;
 
     private Dictionary<Guid, MemberCalculation> _calculations = new();
     private decimal _undistributed;
@@ -27,50 +28,40 @@ public class BasicSalaryAlgorithm
     /// <summary>
     ///     Инициализирует новый экземпляр алгоритма расчета зарплат.
     /// </summary>
-    /// <param name="raids">Список рейдов за период с полной информацией.</param>
-    /// <param name="salary">Зарплатный период.</param>
-    /// <param name="loot">Проданный лут за период.</param>
-    /// <param name="guildLeader">Доли руководства гильдии.</param>
-    /// <param name="expenses">Расходы и отчисления периода.</param>
-    /// <param name="members">Участники зарплатного периода.</param>
-    public BasicSalaryAlgorithm(
-        IList<RaidFullInfo> raids,
-        Salary salary,
-        IList<SalaryLoot> loot,
-        IList<SalaryGuildLeader> guildLeader,
-        IList<SalaryExpenses> expenses,
-        IList<SalaryMember> members)
+    public BasicSalaryAlgorithm(SalaryCalculationData calculationData)
     {
-        _raids = raids;
-        _salary = salary;
-        _loot = loot;
-        _guildLeader = guildLeader;
-        _expenses = expenses;
-        _members = members;
+        _salary = calculationData.Salary;
+        _loot = calculationData.SalaryLoots;
+        _guildLeader = calculationData.SalaryGuildLeaderExpanses;
+        _expenses = calculationData.SalaryExpenses;
+        _members = calculationData.SalaryMembers;
+        _raids = calculationData.RaidFullInfos;
     }
 
     /// <summary>
     ///     Главный метод расчёта зарплат
     /// </summary>
-    public IList<SalaryMember> Calculate()
+    public SalaryCalculationResults Calculate()
     {
-        if (_members.Count == 0)
-        {
-            return new List<SalaryMember>();
-        }
+        var emptyResult = new SalaryCalculationResults(
+            new List<SalaryMemberCalculationResult>(),
+            0,
+            0,
+            0,
+            0,
+            0);
 
-        SetAllMembersToZero();
-
-        if (_raids.Count == 0)
+        if (_members.Count == 0
+            || _raids.Count == 0)
         {
-            return _members;
+            return emptyResult;
         }
 
         // Пул для распределения
         var distributionPool = CalculateDistributionPool();
         if (distributionPool <= 0)
         {
-            return _members;
+            return emptyResult;
         }
 
         // Создаём инвентарь лута для списания
@@ -85,14 +76,26 @@ public class BasicSalaryAlgorithm
         // Распределение голды за ответственность
         DistributeResponsibilityGold();
 
-        // Запись по типу выплаты
+        // Сборка результатов по участникам
         var (availableWb, pricePerWb) = GetWorldBossInfusionInfo();
-        AssignPaymentTypes(pricePerWb);
+        var memberResults = BuildMemberResults(pricePerWb);
 
         // Балансировка РБ
-        BalanceWorldBossInfusions(availableWb, pricePerWb);
+        memberResults = BalanceWorldBossInfusions(memberResults, availableWb, pricePerWb);
 
-        return _members;
+        // Подсчёт итоговых значений для отчёта
+        var goldForSalary = memberResults.Sum(m => m.AmountGold);
+        var wbForSalary = memberResults.Sum(m => m.AmountWorldBossInfusion);
+        var wbForSale = availableWb - wbForSalary;
+        var erenorForSalary = memberResults.Sum(m => m.AmountErenorInfusion);
+
+        return new SalaryCalculationResults(
+            memberResults,
+            goldForSalary,
+            wbForSalary,
+            wbForSale,
+            erenorForSalary,
+            0m);
     }
 
     /// <summary>
@@ -242,12 +245,14 @@ public class BasicSalaryAlgorithm
     }
 
     /// <summary>
-    ///     Шаг 6: Запись результатов в SalaryMember по типу выплаты
+    ///     Шаг 6: Сборка результатов расчёта по каждому участнику.
+    ///     Не мутирует SalaryMember, а возвращает список SalaryMemberCalculationResult.
     ///     AmountWorldBossInfusion = опыт синтеза (goldShare / pricePerSynthesisExp)
     /// </summary>
-    private void AssignPaymentTypes(decimal pricePerSynthesisExp)
+    private List<SalaryMemberCalculationResult> BuildMemberResults(decimal pricePerSynthesisExp)
     {
         var totalRaids = _raids.Count;
+        var results = new List<SalaryMemberCalculationResult>();
 
         foreach (var member in _members)
         {
@@ -257,80 +262,104 @@ public class BasicSalaryAlgorithm
             var raidCount = calc?.RaidCount ?? 0;
             var totalGold = activityGold + responsibilityGold;
 
-            member.ActivityGold = activityGold;
-            member.ResponsibilityGold = responsibilityGold;
-            member.ActivityPercentage = totalRaids > 0
+            var activityPercentage = totalRaids > 0
                 ? (decimal)raidCount / totalRaids * 100
                 : 0m;
+
+            decimal amountGold;
+            decimal amountWorldBossInfusion;
 
             switch (member.PaymentType)
             {
                 case SalaryPaymentType.Gold:
-                    member.AmountGold = totalGold;
-                    member.AmountWorldBossInfusion = 0m;
+                    amountGold = totalGold;
+                    amountWorldBossInfusion = 0m;
                     break;
 
                 case SalaryPaymentType.WorldBossInfusion:
                     if (pricePerSynthesisExp > 0)
                     {
-                        member.AmountWorldBossInfusion = totalGold / pricePerSynthesisExp;
-                        member.AmountGold = 0m;
+                        amountWorldBossInfusion = totalGold / pricePerSynthesisExp;
+                        amountGold = 0m;
                     }
                     else
                     {
-                        member.AmountGold = totalGold;
-                        member.AmountWorldBossInfusion = 0m;
+                        amountGold = totalGold;
+                        amountWorldBossInfusion = 0m;
                     }
                     break;
 
                 default:
-                    // Для других типов выплат (например ErenorInfusion) пока устанавливаем в золото
-                    member.AmountGold = totalGold;
-                    member.AmountWorldBossInfusion = 0m;
+                    amountGold = totalGold;
+                    amountWorldBossInfusion = 0m;
                     break;
             }
+
+            results.Add(new SalaryMemberCalculationResult(
+                member.UserId,
+                activityPercentage,
+                activityGold,
+                responsibilityGold,
+                amountGold,
+                amountWorldBossInfusion,
+                0m));
         }
+
+        return results;
     }
 
     /// <summary>
     ///     Шаг 7: Балансировка РБ инфузий - если не хватает опыта синтеза, компенсируем золотом
     /// </summary>
-    private void BalanceWorldBossInfusions(decimal availableSynthesisExp, decimal pricePerSynthesisExp)
+    private List<SalaryMemberCalculationResult> BalanceWorldBossInfusions(
+        List<SalaryMemberCalculationResult> memberResults,
+        decimal availableSynthesisExp,
+        decimal pricePerSynthesisExp)
     {
         if (pricePerSynthesisExp <= 0)
         {
-            return;
+            return memberResults;
         }
 
-        var wbMembers = _members
+        var wbMemberIds = _members
             .Where(m => m.PaymentType == SalaryPaymentType.WorldBossInfusion)
-            .ToList();
+            .Select(m => m.UserId)
+            .ToHashSet();
 
-        if (wbMembers.Count == 0)
+        if (wbMemberIds.Count == 0)
         {
-            return;
+            return memberResults;
         }
 
-        var totalRequestedExp = wbMembers.Sum(m => m.AmountWorldBossInfusion ?? 0m);
+        var totalRequestedExp = memberResults
+            .Where(m => wbMemberIds.Contains(m.MemberId))
+            .Sum(m => m.AmountWorldBossInfusion);
 
         if (totalRequestedExp <= availableSynthesisExp)
         {
-            return;
+            return memberResults;
         }
 
         // Не хватает опыта синтеза - пропорционально уменьшаем и компенсируем золотом
         var ratio = availableSynthesisExp / totalRequestedExp;
 
-        foreach (var member in wbMembers)
+        return memberResults.Select(m =>
         {
-            var originalExp = member.AmountWorldBossInfusion ?? 0m;
-            var actualExp = originalExp * ratio;
-            var deficitExp = originalExp - actualExp;
+            if (!wbMemberIds.Contains(m.MemberId))
+            {
+                return m;
+            }
+
+            var actualExp = m.AmountWorldBossInfusion * ratio;
+            var deficitExp = m.AmountWorldBossInfusion - actualExp;
             var goldCompensation = deficitExp * pricePerSynthesisExp;
 
-            member.AmountWorldBossInfusion = actualExp;
-            member.AmountGold = goldCompensation;
-        }
+            return m with
+            {
+                AmountWorldBossInfusion = actualExp,
+                AmountGold = goldCompensation
+            };
+        }).ToList();
     }
 
     /// <summary>
@@ -440,18 +469,6 @@ public class BasicSalaryAlgorithm
         _calculations[userId] = calc;
 
         return calc;
-    }
-
-    private void SetAllMembersToZero()
-    {
-        foreach (var member in _members)
-        {
-            member.ActivityPercentage = 0m;
-            member.ActivityGold = 0m;
-            member.ResponsibilityGold = 0m;
-            member.AmountGold = 0m;
-            member.AmountWorldBossInfusion = 0m;
-        }
     }
 
     /// <summary>

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryCalculationService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryCalculationService.cs
@@ -3,6 +3,7 @@ using Freaks.Dal.Common.ValueObjects;
 using Freaks.Portal.Bll.Implementation.SalarySummary.Algorithms;
 using Freaks.Portal.Bll.Interfaces.SalarySummary;
 using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.Contracts.ValueObjects.SalarySummary;
 using Freaks.Portal.Dal.Interfaces.RaidSummary;
 using Freaks.Portal.Dal.Interfaces.SalarySummary;
 using Freaks.WebApi.Common.Exceptions;
@@ -20,6 +21,7 @@ public class SalaryCalculationService : ISalaryCalculationService
     private readonly ISalaryGuildLeaderProvider _salaryGuildLeaderProvider;
     private readonly ISalaryExpensesProvider _salaryExpensesProvider;
     private readonly ISalaryMemberProvider _salaryMemberProvider;
+    private readonly ISalaryFinalReportProvider _salaryFinalReportProvider;
     private readonly IRaidProvider _raidProvider;
 
     /// <summary>
@@ -30,6 +32,7 @@ public class SalaryCalculationService : ISalaryCalculationService
     /// <param name="salaryGuildLeaderProvider">Провайдер для работы с долями руководства.</param>
     /// <param name="salaryExpensesProvider">Провайдер для работы с расходами.</param>
     /// <param name="salaryMemberProvider">Провайдер для работы с участниками.</param>
+    /// <param name="salaryFinalReportProvider">Провайдер для работы с итоговым отчётом.</param>
     /// <param name="raidProvider">Провайдер для работы с рейдами.</param>
     /// <exception cref="ArgumentNullException">Выбрасывается, если один из аргументов равен null.</exception>
     public SalaryCalculationService(
@@ -38,6 +41,7 @@ public class SalaryCalculationService : ISalaryCalculationService
         ISalaryGuildLeaderProvider salaryGuildLeaderProvider,
         ISalaryExpensesProvider salaryExpensesProvider,
         ISalaryMemberProvider salaryMemberProvider,
+        ISalaryFinalReportProvider salaryFinalReportProvider,
         IRaidProvider raidProvider)
     {
         _salaryProvider = salaryProvider ?? throw new ArgumentNullException(nameof(salaryProvider));
@@ -45,6 +49,7 @@ public class SalaryCalculationService : ISalaryCalculationService
         _salaryGuildLeaderProvider = salaryGuildLeaderProvider ?? throw new ArgumentNullException(nameof(salaryGuildLeaderProvider));
         _salaryExpensesProvider = salaryExpensesProvider ?? throw new ArgumentNullException(nameof(salaryExpensesProvider));
         _salaryMemberProvider = salaryMemberProvider ?? throw new ArgumentNullException(nameof(salaryMemberProvider));
+        _salaryFinalReportProvider = salaryFinalReportProvider ?? throw new ArgumentNullException(nameof(salaryFinalReportProvider));
         _raidProvider = raidProvider ?? throw new ArgumentNullException(nameof(raidProvider));
     }
 
@@ -64,10 +69,35 @@ public class SalaryCalculationService : ISalaryCalculationService
 
         var raids = await _raidProvider.GetFullInfoAsync(salary.StartDt.ToDateTimeOffset(), salary.EndDt.AddDays(1).ToDateTimeOffset(), salary.BossTypes);
 
-        var algorithm =
-            new BasicSalaryAlgorithm(raids, salary, salaryLoot, salaryGuildLeader, salaryExpenses, salaryMembers);
+        var calculationData =
+            new SalaryCalculationData(salary, salaryLoot, salaryGuildLeader, salaryExpenses, salaryMembers, raids);
+        var algorithm = new BasicSalaryAlgorithm(calculationData);
 
-        var membersResult = algorithm.Calculate();
-        await _salaryMemberProvider.UpdateSetAsync(membersResult);
+        var result = algorithm.Calculate();
+
+        var salaryFinalReport = await _salaryFinalReportProvider.GetAsync(salaryId, EntityTrackingType.NoTracking);
+        if (salaryFinalReport is null)
+        {
+            throw new InvalidOperationException("Salary final report not found.");
+        }
+
+        foreach (var memberResult in result.MembersResult)
+        {
+            var member = salaryMembers.First(m => m.UserId == memberResult.MemberId);
+
+            member.ActivityPercentage = memberResult.ActivityPercentage;
+            member.ActivityGold = memberResult.ActivityGold;
+            member.ResponsibilityGold = memberResult.ResponsibilityGold;
+            member.AmountGold = memberResult.AmountGold;
+            member.AmountWorldBossInfusion = memberResult.AmountWorldBossInfusion;
+        }
+        await _salaryMemberProvider.UpdateSetAsync(salaryMembers);
+
+        salaryFinalReport.GoldForSalary = result.GoldForSalary;
+        salaryFinalReport.WorldBossInfusionForSalary = result.WorldBossInfusionForSalary;
+        salaryFinalReport.WorldBossInfusionForSale = result.WorldBossInfusionForSale;
+        salaryFinalReport.ErenorInfusionForSalary = result.ErenorInfusionForSalary;
+        salaryFinalReport.ErenorInfusionForSale = result.ErenorInfusionForSale;
+        await _salaryFinalReportProvider.UpdateAsync(salaryFinalReport);
     }
 }

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryFinalReportService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryFinalReportService.cs
@@ -1,0 +1,139 @@
+﻿using Freaks.Dal.Common.Interfaces;
+using Freaks.Dal.Common.ValueObjects;
+using Freaks.Portal.Bll.Implementation.SalarySummary.Helpers;
+using Freaks.Portal.Bll.Interfaces.SalarySummary;
+using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.Dal.Interfaces.SalarySummary;
+using Freaks.Portal.Dal.Persistence;
+using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+using Freaks.Portal.SharedContracts.ValueObjects.Loot;
+using Freaks.Portal.SharedContracts.ValueObjects.SalarySummary;
+using Freaks.WebApi.Common.Exceptions;
+using Freaks.WebApi.Common.Exceptions.Salary;
+using MapsterMapper;
+
+namespace Freaks.Portal.Bll.Implementation.SalarySummary;
+
+/// <summary>
+///     Сервис для работы с итоговым отчётом зарплатного периода.
+///     Формирует и рассчитывает итоговые данные по распределению лута, расходам и выплатам.
+/// </summary>
+public class SalaryFinalReportService : ISalaryFinalReportService
+{
+    private readonly IMapper _mapper;
+    private readonly ISalaryProvider _salaryProvider;
+    private readonly ISalaryLootProvider _lootProvider;
+    private readonly ISalaryGuildLeaderProvider _guildLeaderProvider;
+    private readonly ISalaryExpensesProvider _expensesProvider;
+    private readonly ISalaryFinalReportProvider _provider;
+    private readonly ISalaryStepService _stepService;
+    private readonly ISalaryCalculationService _calculationService;
+    private readonly IUnitOfWork<PortalDbContext> _uow;
+
+    /// <summary>
+    ///     Инициализирует новый экземпляр сервиса <see cref="SalaryFinalReportService" />.
+    /// </summary>
+    /// <param name="mapper">Сервис Mapster для преобразования между моделями.</param>
+    /// <param name="provider">Провайдер для работы с итоговыми отчётами.</param>
+    /// <param name="salaryProvider">Провайдер для работы с зарплатными периодами.</param>
+    /// <param name="lootProvider">Провайдер для работы с проданным лутом.</param>
+    /// <param name="guildLeaderProvider">Провайдер для работы с долями руководства.</param>
+    /// <param name="expensesProvider">Провайдер для работы с расходами.</param>
+    /// <param name="stepService">Сервис степпера зарплатных периодов.</param>
+    /// <param name="calculationService">Сервис расчёта зарплат.</param>
+    /// <param name="uow">Unit of work.</param>
+    /// <exception cref="ArgumentNullException">Выбрасывается, если один из аргументов равен null.</exception>
+    public SalaryFinalReportService(
+        IMapper mapper,
+        ISalaryFinalReportProvider provider,
+        ISalaryProvider salaryProvider,
+        ISalaryLootProvider lootProvider,
+        ISalaryGuildLeaderProvider guildLeaderProvider,
+        ISalaryExpensesProvider expensesProvider,
+        ISalaryStepService stepService,
+        ISalaryCalculationService calculationService,
+        IUnitOfWork<PortalDbContext> uow)
+    {
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        _salaryProvider = salaryProvider ?? throw new ArgumentNullException(nameof(salaryProvider));
+        _lootProvider = lootProvider ?? throw new ArgumentNullException(nameof(lootProvider));
+        _guildLeaderProvider = guildLeaderProvider ?? throw new ArgumentNullException(nameof(guildLeaderProvider));
+        _expensesProvider = expensesProvider ?? throw new ArgumentNullException(nameof(expensesProvider));
+        _stepService = stepService ?? throw new ArgumentNullException(nameof(stepService));
+        _calculationService = calculationService ?? throw new ArgumentNullException(nameof(calculationService));
+        _uow = uow ?? throw new ArgumentNullException(nameof(uow));
+    }
+
+    /// <inheritdoc />
+    public Task<SalaryFinalReportDto> GetAsync(long salaryId)
+    {
+        return _uow.ExecuteInsideTransactionAsync(async _ =>
+        {
+            var salary = await _salaryProvider.GetAsync(salaryId, EntityTrackingType.NoTracking);
+            if (salary is null)
+            {
+                throw new EntityNotFoundException(nameof(Salary));
+            }
+
+            if (salary.RegistrationStatus is not SalaryRegistrationStatus.Ended)
+            {
+                throw new SalaryRegistrationNotEndedYetException();
+            }
+
+            await _stepService.HandleStepActionAsync(salaryId, SalaryFillStepType.FinalReports);
+
+            var finalReport = await _provider.GetAsync(salaryId, EntityTrackingType.NoTracking);
+            if (finalReport is null)
+            {
+                finalReport = new SalaryFinalReport
+                {
+                    Id = salaryId,
+                };
+                await _provider.CreateAsync(finalReport);
+
+                await _calculationService.CalculateAsync(salaryId);
+            }
+
+            if (salary.IsFinished)
+            {
+                return _mapper.Map<SalaryFinalReportDto>(finalReport);
+            }
+
+            var salaryLoot = await _lootProvider.GetBySalaryIdAsync(salaryId);
+            var guildLeaderExpenses = await _guildLeaderProvider.GetBySalaryIdAsync(salaryId);
+            var expenses = await _expensesProvider.GetBySalaryIdAsync(salaryId);
+
+            // Общий итог зарплатного периода
+            finalReport.TotalGold = salaryLoot
+                .Where(l => l.LootItem!.Type is not LootType.WorldBossInfusion and LootType.ErenorInfusion)
+                .Sum(x => x.Amount);
+            finalReport.TotalWorldBossInfusion = salaryLoot
+                .Where(l => l.LootItem!.Type is LootType.WorldBossInfusion)
+                .Sum(x => x.Quantity * x.LootItem!.SynthesisExp!.Value);
+            finalReport.TotalWorldBossInfusion = salaryLoot
+                .Where(l => l.LootItem!.Type is LootType.ErenorInfusion)
+                .Sum(x => x.Quantity * x.LootItem!.SynthesisExp!.Value);
+
+            // Итого сколько забрал ГЛ
+            finalReport.GoldGuildLeaderExpenses = guildLeaderExpenses
+                .Where(gl => gl.SalaryLoot!.LootItem!.Type is not LootType.WorldBossInfusion and LootType.ErenorInfusion)
+                .Sum(gl => SalaryGuildLeaderHelper.CalculateAmount(gl.SalaryLoot, gl.Quantity));
+            finalReport.WorldBossInfusionGuildLeaderExpenses = guildLeaderExpenses
+                .Where(gl => gl.SalaryLoot!.LootItem!.Type is LootType.WorldBossInfusion)
+                .Sum(gl => gl.SalaryLoot!.Quantity * gl.SalaryLoot!.LootItem!.SynthesisExp!.Value);
+            finalReport.ErenorInfusionGuildLeaderExpenses = guildLeaderExpenses
+                .Where(gl => gl.SalaryLoot!.LootItem!.Type is LootType.ErenorInfusion)
+                .Sum(gl => gl.SalaryLoot!.Quantity * gl.SalaryLoot!.LootItem!.SynthesisExp!.Value);
+
+            // Итого сколько ушло на расходы гильдии
+            finalReport.GoldExpenses = expenses.Sum(x => x.Amount);
+            finalReport.WorldBossInfusionExpenses = 0; // TODO
+            finalReport.ErenorInfusionExpenses = 0; // TODO
+
+            await _provider.UpdateAsync(finalReport);
+
+            return _mapper.Map<SalaryFinalReportDto>(finalReport);
+        });
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Implementation/SalarySummary/SalaryService.cs
@@ -150,7 +150,7 @@ public class SalaryService : ISalaryService
     {
         return _unitOfWork.ExecuteInsideTransactionAsync(async _ =>
         {
-            await _stepService.HandleStepActionAsync(id, SalaryFillStepType.FinalReports);
+            await _stepService.HandleStepActionAsync(id, SalaryFillStepType.Members);
 
             var entity = await _provider.GetAsync(id, EntityTrackingType.NoTracking);
             if (entity is null)
@@ -158,7 +158,7 @@ public class SalaryService : ISalaryService
                 throw new EntityNotFoundException(nameof(Salary));
             }
 
-            entity.FillStepType = SalaryFillStepType.FinalReports;
+            entity.IsFinished = true;
 
             entity.UpdatedDt = DateTime.UtcNow;
 

--- a/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Interfaces/SalarySummary/ISalaryFinalReportService.cs
+++ b/src/backend/dotnet/Services/Portal/Bll/Freaks.Portal.Bll.Interfaces/SalarySummary/ISalaryFinalReportService.cs
@@ -1,0 +1,17 @@
+﻿using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+
+namespace Freaks.Portal.Bll.Interfaces.SalarySummary;
+
+/// <summary>
+///     Интерфейс сервиса для работы с итоговым отчётом зарплатного периода.
+/// </summary>
+public interface ISalaryFinalReportService
+{
+    /// <summary>
+    ///     Получает итоговый отчёт по зарплатному периоду.
+    ///     Если отчёт ещё не существует — создаёт его и запускает расчёт.
+    /// </summary>
+    /// <param name="salaryId">Идентификатор зарплатного периода.</param>
+    /// <returns>DTO итогового отчёта.</returns>
+    Task<SalaryFinalReportDto> GetAsync(long salaryId);
+}

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/ConfigureServices.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/ConfigureServices.cs
@@ -57,6 +57,7 @@ public static class ConfigureServices
         services.AddScoped<ISalaryMemberProvider, SalaryMemberProvider>();
         services.AddScoped<ISalaryExpensesProvider, SalaryExpensesProvider>();
         services.AddScoped<ISalaryGuildLeaderProvider, SalaryGuildLeaderProvider>();
+        services.AddScoped<ISalaryFinalReportProvider, SalaryFinalReportProvider>();
         services.AddScoped<ISalaryLootProvider, SalaryLootProvider>();
 
         services.AddEasyCachingCommon(configuration);

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryFinalReportProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Implementation/SalarySummary/SalaryFinalReportProvider.cs
@@ -1,0 +1,44 @@
+﻿using Freaks.Dal.Common.Implementations;
+using Freaks.Dal.Common.Interfaces;
+using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.Dal.Interfaces.SalarySummary;
+using Freaks.Portal.Dal.Persistence;
+
+namespace Freaks.Portal.Dal.Implementation.SalarySummary;
+
+/// <summary>
+///     Провайдер для работы с итоговыми отчётами зарплатных периодов.
+///     Использует кэширование для ускорения доступа к данным.
+/// </summary>
+public class SalaryFinalReportProvider : BaseCachedProvider<SalaryFinalReport, long, IPortalDbContext>, ISalaryFinalReportProvider
+{
+    /// <summary>
+    ///     Инициализирует новый экземпляр провайдера <see cref="SalaryFinalReportProvider" />.
+    /// </summary>
+    /// <param name="dbContext">Контекст базы данных портала.</param>
+    /// <param name="cacheProvider">Провайдер кэширования.</param>
+    public SalaryFinalReportProvider(IPortalDbContext dbContext, ICacheProvider cacheProvider) : base(dbContext, cacheProvider)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string GetCacheKey(long key)
+    {
+        return $"{nameof(SalaryFinalReport)}:{key}";
+    }
+
+    /// <inheritdoc />
+    protected override List<string> GetAllCacheKeys(SalaryFinalReport entity)
+    {
+        return
+        [
+            GetCacheKey(entity.Id)
+        ];
+    }
+
+    /// <inheritdoc />
+    protected override List<string> GetAllCachePrefixes(SalaryFinalReport entity)
+    {
+        return [];
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Interfaces/SalarySummary/ISalaryFinalReportProvider.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Interfaces/SalarySummary/ISalaryFinalReportProvider.cs
@@ -1,0 +1,12 @@
+﻿using Freaks.Dal.Common.Interfaces;
+using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.Dal.Persistence;
+
+namespace Freaks.Portal.Dal.Interfaces.SalarySummary;
+
+/// <summary>
+///     Интерфейс провайдера для работы с итоговыми отчётами зарплатных периодов.
+/// </summary>
+public interface ISalaryFinalReportProvider : IBaseProvider<SalaryFinalReport, long, IPortalDbContext>
+{
+}

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Configurations/Salary/SalaryFinalReportConfiguration.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Configurations/Salary/SalaryFinalReportConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Freaks.Portal.Dal.Persistence.Configurations.Salary;
+
+/// <summary>
+///     Конфигурация EF Core для сущности <see cref="SalaryFinalReport" />.
+/// </summary>
+public class SalaryFinalReportConfiguration : IEntityTypeConfiguration<SalaryFinalReport>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<SalaryFinalReport> builder)
+    {
+        builder
+            .HasOne(s => s.Salary)
+            .WithOne()
+            .HasForeignKey<SalaryFinalReport>(s => s.Id)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/IPortalDbContext.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/IPortalDbContext.cs
@@ -95,4 +95,9 @@ public interface IPortalDbContext : IBaseDbContext
     ///    Набор расходов в зарплатных отчётах.
     /// </summary>
     DbSet<SalaryExpenses> SalaryExpenses { get; }
+
+    /// <summary>
+    ///     Набор итоговых отчётов зарплатных периодов.
+    /// </summary>
+    DbSet<SalaryFinalReport> SalaryFinalReports { get; }
 }

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260212052404_added_salary_final_report_table.Designer.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260212052404_added_salary_final_report_table.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Freaks.Portal.Dal.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Freaks.Portal.Dal.Persistence.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    partial class PortalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260212052404_added_salary_final_report_table")]
+    partial class added_salary_final_report_table
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260212052404_added_salary_final_report_table.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/Migrations/20260212052404_added_salary_final_report_table.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Freaks.Portal.Dal.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class added_salary_final_report_table : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_finished",
+                schema: "portal",
+                table: "salary",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "salary_final_report",
+                schema: "portal",
+                columns: table => new
+                {
+                    salary_id = table.Column<long>(type: "bigint", nullable: false),
+                    total_gold = table.Column<decimal>(type: "numeric", nullable: false),
+                    total_world_boss_infusion = table.Column<int>(type: "integer", nullable: false),
+                    total_erenor_infusion = table.Column<int>(type: "integer", nullable: false),
+                    gold_guild_leader_expenses = table.Column<decimal>(type: "numeric", nullable: false),
+                    world_boss_infusion_guild_leader_expenses = table.Column<int>(type: "integer", nullable: false),
+                    erenor_infusion_guild_leader_expenses = table.Column<int>(type: "integer", nullable: false),
+                    gold_expenses = table.Column<decimal>(type: "numeric", nullable: false),
+                    world_boss_infusion_expenses = table.Column<decimal>(type: "numeric", nullable: false),
+                    erenor_infusion_expenses = table.Column<decimal>(type: "numeric", nullable: false),
+                    gold_for_salary = table.Column<decimal>(type: "numeric", nullable: false),
+                    world_boss_infusion_for_salary = table.Column<decimal>(type: "numeric", nullable: false),
+                    world_boss_infusion_for_sale = table.Column<decimal>(type: "numeric", nullable: false),
+                    erenor_infusion_for_salary = table.Column<decimal>(type: "numeric", nullable: false),
+                    erenor_infusion_for_sale = table.Column<decimal>(type: "numeric", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_salary_final_report", x => x.salary_id);
+                    table.ForeignKey(
+                        name: "FK_salary_final_report_salary_salary_id",
+                        column: x => x.salary_id,
+                        principalSchema: "portal",
+                        principalTable: "salary",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "salary_final_report",
+                schema: "portal");
+
+            migrationBuilder.DropColumn(
+                name: "is_finished",
+                schema: "portal",
+                table: "salary");
+        }
+    }
+}

--- a/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/PortalDbContext.cs
+++ b/src/backend/dotnet/Services/Portal/Dal/Freaks.Portal.Dal.Persistence/PortalDbContext.cs
@@ -78,6 +78,9 @@ public class PortalDbContext : DbContext, IPortalDbContext
     public DbSet<SalaryExpenses> SalaryExpenses { get; init; }
 
     /// <inheritdoc />
+    public DbSet<SalaryFinalReport> SalaryFinalReports { get; init; }
+
+    /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/Entities/SalarySummary/Salary.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/Entities/SalarySummary/Salary.cs
@@ -84,4 +84,10 @@ public class Salary : IEntity<long>
     /// </summary>
     [Column("updated_dt")]
     public DateTime? UpdatedDt { get; set; }
+
+    /// <summary>
+    ///     Признак: зарплатный период завершён
+    /// </summary>
+    [Column("is_finished")]
+    public bool IsFinished { get; set; }
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/Entities/SalarySummary/SalaryFinalReport.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/Entities/SalarySummary/SalaryFinalReport.cs
@@ -1,0 +1,108 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Freaks.Contracts.Common.Interfaces;
+using Freaks.Dal.Common.Consts;
+
+namespace Freaks.Portal.Contracts.Entities.SalarySummary;
+
+/// <summary>
+///     Итоговый отчёт зарплатного периода.
+///     Содержит агрегированные данные по доходам, расходам и распределению ресурсов.
+/// </summary>
+[Table("salary_final_report", Schema = DatabaseConsts.PortalSchema)]
+public class SalaryFinalReport : IEntity<long>
+{
+    /// <inheritdoc />
+    [Key]
+    [Column("salary_id")]
+    public long Id { get; init; }
+
+    /// <summary>
+    ///     Общий доход в золоте за период.
+    /// </summary>
+    [Column("total_gold")]
+    public decimal TotalGold { get; set; }
+
+    /// <summary>
+    ///     Общий доход в опыте синтеза инфузий мирового босса за период.
+    /// </summary>
+    [Column("total_world_boss_infusion")]
+    public int TotalWorldBossInfusion { get; set; }
+
+    /// <summary>
+    ///     Общий доход в опыте синтеза эренорских инфузий за период.
+    /// </summary>
+    [Column("total_erenor_infusion")]
+    public int TotalErenorInfusion { get; set; }
+
+    /// <summary>
+    ///     Золото, забранное руководством гильдии.
+    /// </summary>
+    [Column("gold_guild_leader_expenses")]
+    public decimal GoldGuildLeaderExpenses { get; set; }
+
+    /// <summary>
+    ///     Инфузии мирового босса, забранные руководством гильдии (опыт синтеза).
+    /// </summary>
+    [Column("world_boss_infusion_guild_leader_expenses")]
+    public int WorldBossInfusionGuildLeaderExpenses { get; set; }
+
+    /// <summary>
+    ///     Эренорские инфузии, забранные руководством гильдии (опыт синтеза).
+    /// </summary>
+    [Column("erenor_infusion_guild_leader_expenses")]
+    public int ErenorInfusionGuildLeaderExpenses { get; set; }
+
+    /// <summary>
+    ///     Расходы гильдии в золоте.
+    /// </summary>
+    [Column("gold_expenses")]
+    public decimal GoldExpenses { get; set; }
+
+    /// <summary>
+    ///     Расходы гильдии в инфузиях мирового босса (опыт синтеза).
+    /// </summary>
+    [Column("world_boss_infusion_expenses")]
+    public decimal WorldBossInfusionExpenses { get; set; }
+
+    /// <summary>
+    ///     Расходы гильдии в эренорских инфузиях (опыт синтеза).
+    /// </summary>
+    [Column("erenor_infusion_expenses")]
+    public decimal ErenorInfusionExpenses { get; set; }
+
+    /// <summary>
+    ///     Золото, распределённое участникам в качестве зарплаты.
+    /// </summary>
+    [Column("gold_for_salary")]
+    public decimal GoldForSalary { get; set; }
+
+    /// <summary>
+    ///     Инфузии мирового босса, распределённые участникам (опыт синтеза).
+    /// </summary>
+    [Column("world_boss_infusion_for_salary")]
+    public decimal WorldBossInfusionForSalary { get; set; }
+
+    /// <summary>
+    ///     Инфузии мирового босса, оставшиеся на продажу (опыт синтеза).
+    /// </summary>
+    [Column("world_boss_infusion_for_sale")]
+    public decimal WorldBossInfusionForSale { get; set; }
+
+    /// <summary>
+    ///     Эренорские инфузии, распределённые участникам (опыт синтеза).
+    /// </summary>
+    [Column("erenor_infusion_for_salary")]
+    public decimal ErenorInfusionForSalary { get; set; }
+
+    /// <summary>
+    ///     Эренорские инфузии, оставшиеся на продажу (опыт синтеза).
+    /// </summary>
+    [Column("erenor_infusion_for_sale")]
+    public decimal ErenorInfusionForSale { get; set; }
+
+    /// <summary>
+    ///     Навигационное свойство для доступа к зарплатному периоду.
+    /// </summary>
+    public Salary? Salary { get; init; }
+}

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/ValueObjects/SalarySummary/SalaryCalculationData.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/ValueObjects/SalarySummary/SalaryCalculationData.cs
@@ -1,0 +1,21 @@
+﻿using Freaks.Portal.Contracts.Entities.SalarySummary;
+using Freaks.Portal.Contracts.ValueObjects.RaidSummary;
+
+namespace Freaks.Portal.Contracts.ValueObjects.SalarySummary;
+
+/// <summary>
+///     Входные данные для алгоритма расчёта зарплат.
+/// </summary>
+/// <param name="Salary">Зарплатный период.</param>
+/// <param name="SalaryLoots">Проданный лут за период.</param>
+/// <param name="SalaryGuildLeaderExpanses">Доля руководства гильдии.</param>
+/// <param name="SalaryExpenses">Расходы и отчисления.</param>
+/// <param name="SalaryMembers">Участники зарплатного периода.</param>
+/// <param name="RaidFullInfos">Рейды с полной информацией (участники, лут).</param>
+public record SalaryCalculationData(
+    Salary Salary,
+    IList<SalaryLoot> SalaryLoots,
+    IList<SalaryGuildLeader> SalaryGuildLeaderExpanses,
+    IList<SalaryExpenses> SalaryExpenses,
+    IList<SalaryMember> SalaryMembers,
+    IList<RaidFullInfo> RaidFullInfos);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/ValueObjects/SalarySummary/SalaryCalculationResults.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/ValueObjects/SalarySummary/SalaryCalculationResults.cs
@@ -1,0 +1,18 @@
+﻿namespace Freaks.Portal.Contracts.ValueObjects.SalarySummary;
+
+/// <summary>
+///     Результаты расчёта зарплат за период.
+/// </summary>
+/// <param name="MembersResult">Результаты расчёта по каждому участнику.</param>
+/// <param name="GoldForSalary">Золото, распределённое участникам.</param>
+/// <param name="WorldBossInfusionForSalary">Опыт синтеза инфузий мирового босса, распределённый участникам.</param>
+/// <param name="WorldBossInfusionForSale">Опыт синтеза инфузий мирового босса, оставшийся на продажу.</param>
+/// <param name="ErenorInfusionForSalary">Опыт синтеза эренорских инфузий, распределённый участникам.</param>
+/// <param name="ErenorInfusionForSale">Опыт синтеза эренорских инфузий, оставшийся на продажу.</param>
+public record SalaryCalculationResults(
+    IList<SalaryMemberCalculationResult> MembersResult,
+    decimal GoldForSalary,
+    decimal WorldBossInfusionForSalary,
+    decimal WorldBossInfusionForSale,
+    decimal ErenorInfusionForSalary,
+    decimal ErenorInfusionForSale);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/ValueObjects/SalarySummary/SalaryMemberCalculationResult.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.Contracts/ValueObjects/SalarySummary/SalaryMemberCalculationResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Freaks.Portal.Contracts.ValueObjects.SalarySummary;
+
+/// <summary>
+///     Результат расчёта зарплаты для отдельного участника.
+/// </summary>
+/// <param name="MemberId">Идентификатор пользователя.</param>
+/// <param name="ActivityPercentage">Процент активности (доля посещённых рейдов).</param>
+/// <param name="ActivityGold">Золото, начисленное за активность (участие в рейдах).</param>
+/// <param name="ResponsibilityGold">Золото, начисленное за ответственность.</param>
+/// <param name="AmountGold">Итоговая сумма к выплате в золоте.</param>
+/// <param name="AmountWorldBossInfusion">Итоговая сумма к выплате в опыте синтеза инфузий мирового босса.</param>
+/// <param name="AmountErenorInfusion">Итоговая сумма к выплате в опыте синтеза эренорских инфузий.</param>
+public record SalaryMemberCalculationResult(
+    Guid MemberId,
+    decimal ActivityPercentage,
+    decimal ActivityGold,
+    decimal ResponsibilityGold,
+    decimal AmountGold,
+    decimal AmountWorldBossInfusion,
+    decimal AmountErenorInfusion);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Dto/SalarySummary/SalaryDto.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Dto/SalarySummary/SalaryDto.cs
@@ -16,6 +16,7 @@ namespace Freaks.Portal.SharedContracts.Dto.SalarySummary;
 /// <param name="AllowedPaymentTypes">Разрешённые способы получения ЗП.</param>
 /// <param name="UseCoefficients">Признак: использовать коэффициентную систему.</param>
 /// <param name="BossTypes">Учитываемые боссы.</param>
+/// <param name="IsFinished">Признак: зарплатный период завершён.</param>
 public record SalaryDto(
     long Id,
     string Name,
@@ -25,4 +26,5 @@ public record SalaryDto(
     SalaryRegistrationStatus RegistrationStatus,
     IList<SalaryPaymentType> AllowedPaymentTypes,
     bool UseCoefficients,
-    IList<BossType> BossTypes);
+    IList<BossType> BossTypes,
+    bool IsFinished);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Dto/SalarySummary/SalaryFinalReportDto.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/Dto/SalarySummary/SalaryFinalReportDto.cs
@@ -1,0 +1,30 @@
+﻿namespace Freaks.Portal.SharedContracts.Dto.SalarySummary;
+
+/// <summary>
+///     DTO итогового отчёта зарплатного периода.
+/// </summary>
+/// <param name="TotalGold">Общий доход в золоте за период.</param>
+/// <param name="TotalWorldBossInfusion">Общий доход в опыте синтеза инфузий мирового босса.</param>
+/// <param name="TotalErenorInfusion">Общий доход в опыте синтеза эренорских инфузий.</param>
+/// <param name="GoldGuildLeaderExpenses">Золото, забранное руководством гильдии.</param>
+/// <param name="WorldBossInfusionGuildLeaderExpenses">Инфузии мирового босса, забранные руководством.</param>
+/// <param name="ErenorInfusionGuildLeaderExpenses">Эренорские инфузии, забранные руководством.</param>
+/// <param name="GoldExpenses">Расходы гильдии в золоте.</param>
+/// <param name="WorldBossInfusionExpenses">Расходы гильдии в инфузиях мирового босса.</param>
+/// <param name="ErenorInfusionExpenses">Расходы гильдии в эренорских инфузиях.</param>
+/// <param name="GoldForSale">Золото, оставшееся на продажу.</param>
+/// <param name="WorldBossInfusionForSale">Инфузии мирового босса, оставшиеся на продажу.</param>
+/// <param name="ErenorInfusionForSale">Эренорские инфузии, оставшиеся на продажу.</param>
+public record SalaryFinalReportDto(
+    decimal TotalGold,
+    decimal TotalWorldBossInfusion,
+    decimal TotalErenorInfusion,
+    decimal GoldGuildLeaderExpenses,
+    decimal WorldBossInfusionGuildLeaderExpenses,
+    decimal ErenorInfusionGuildLeaderExpenses,
+    decimal GoldExpenses,
+    decimal WorldBossInfusionExpenses,
+    decimal ErenorInfusionExpenses,
+    decimal GoldForSale,
+    decimal WorldBossInfusionForSale,
+    decimal ErenorInfusionForSale);

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/ValueObjects/SalarySummary/SalaryFillStepType.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.SharedContracts/ValueObjects/SalarySummary/SalaryFillStepType.cs
@@ -29,4 +29,9 @@ public enum SalaryFillStepType
     ///     Итоговый отчёт
     /// </summary>
     FinalReports = 40,
+
+    /// <summary>
+    ///     Распределение зарплат участникам
+    /// </summary>
+    Members = 50,
 }

--- a/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Controllers/SalarySummary/SalaryFinalReportController.cs
+++ b/src/backend/dotnet/Services/Portal/Freaks.Portal.WebApi/Controllers/SalarySummary/SalaryFinalReportController.cs
@@ -1,0 +1,41 @@
+using Freaks.Portal.Bll.Interfaces.SalarySummary;
+using Freaks.Portal.SharedContracts.Dto.SalarySummary;
+using Freaks.Users.Common.Attributes;
+using Freaks.Users.Contracts.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Freaks.Portal.WebApi.Controllers.SalarySummary;
+
+/// <summary>
+///     Контроллер для получения итогового отчёта зарплатного периода.
+/// </summary>
+[ApiController]
+[Authorize]
+[RequireRoles(UserRole.Member)]
+[Route("salaries/{salaryId:long}/final-report")]
+public class SalaryFinalReportController : ControllerBase
+{
+    private readonly ISalaryFinalReportService _service;
+
+    /// <summary>
+    ///     Инициализирует новый экземпляр контроллера для работы с итоговым отчётом зарплатного периода.
+    /// </summary>
+    /// <param name="service">Сервис для работы с итоговыми отчётами.</param>
+    public SalaryFinalReportController(ISalaryFinalReportService service)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+    }
+
+    /// <summary>
+    ///     Получает итоговый отчёт по указанному зарплатному периоду.
+    ///     Если отчёт ещё не существует — создаёт его и запускает расчёт.
+    /// </summary>
+    /// <param name="salaryId">Идентификатор зарплатного периода.</param>
+    /// <returns>Итоговый отчёт зарплатного периода.</returns>
+    [HttpGet]
+    public Task<SalaryFinalReportDto> GetAsync([FromRoute] long salaryId)
+    {
+        return _service.GetAsync(salaryId);
+    }
+}

--- a/src/backend/dotnet/Shared/Freaks.WebApi.Common/Exceptions/Salary/SalaryRegistrationNotEndedYetException.cs
+++ b/src/backend/dotnet/Shared/Freaks.WebApi.Common/Exceptions/Salary/SalaryRegistrationNotEndedYetException.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using Freaks.WebApi.Common.Exceptions.Base;
+
+namespace Freaks.WebApi.Common.Exceptions.Salary;
+
+/// <summary>
+///     Исключение, выбрасываемое при попытке выполнить действие до завершения регистрации на зарплатный период.
+/// </summary>
+public class SalaryRegistrationNotEndedYetException : BadRequestApiException
+{
+    /// <inheritdoc />
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+
+    /// <inheritdoc />
+    public override string ErrorCode => "SALARY_REGISTRATION_NOT_ENDED_YET_EXCEPTION";
+
+    /// <summary>
+    ///     Инициализирует новый экземпляр <see cref="SalaryRegistrationNotEndedYetException" />.
+    /// </summary>
+    /// <param name="message">Сообщение об ошибке.</param>
+    /// <param name="innerException">Вложенное исключение (если есть).</param>
+    public SalaryRegistrationNotEndedYetException(string? message = null, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}


### PR DESCRIPTION
- Created the `salary_final_report` table to store aggregated salary data, including totals and expense breakdowns.
- Added `is_finished` column to the `salary` table to indicate salary period status.
- Updated schema relationships with foreign key constraints linking `salary_final_report` to the `salary` table.
- Included accompanying migration files.